### PR TITLE
Fix for a pipe overflow affecting snow-chibi

### DIFF
--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -1300,7 +1300,7 @@ SEXP_API sexp sexp_push_op(sexp ctx, sexp* loc, sexp x);
 
 #define sexp_read_char(x, p) (sexp_port_buf(p) ? ((sexp_port_offset(p) < sexp_port_size(p)) ? ((unsigned char*)sexp_port_buf(p))[sexp_port_offset(p)++] : sexp_buffered_read_char(x, p)) : getc(sexp_port_stream(p)))
 #define sexp_push_char(x, c, p) ((c!=EOF) && (sexp_port_buf(p) ? (sexp_port_buf(p)[--sexp_port_offset(p)] = ((char)(c))) : ungetc(c, sexp_port_stream(p))))
-#define sexp_write_char(x, c, p) (sexp_port_buf(p) ? ((sexp_port_offset(p) < sexp_port_size(p)) ? ((((sexp_port_buf(p))[sexp_port_offset(p)++]) = (char)(c)), 0) : sexp_buffered_write_char(x, c, p)) : putc(c, sexp_port_stream(p)))
+#define sexp_write_char(x, c, p) (sexp_port_buf(p) ? ((sexp_port_offset(p) < sexp_port_size(p)) ? ((((sexp_port_buf(p))[sexp_port_offset(p)++]) = (char)(c)), (int)(c)) : sexp_buffered_write_char(x, c, p)) : putc(c, sexp_port_stream(p)))
 #define sexp_write_string(x, s, p) (sexp_port_buf(p) ? sexp_buffered_write_string(x, s, p) : fputs(s, sexp_port_stream(p)))
 #define sexp_write_string_n(x, s, n, p) (sexp_port_buf(p) ? sexp_buffered_write_string_n(x, s, n, p) : fwrite(s, 1, n, sexp_port_stream(p)))
 #define sexp_flush(x, p) (sexp_port_buf(p) ? sexp_buffered_flush(x, p, 0) : fflush(sexp_port_stream(p)))

--- a/lib/chibi/io-test.sld
+++ b/lib/chibi/io-test.sld
@@ -2,7 +2,8 @@
   (export run-tests)
   (import (chibi)
           (chibi io)
-          (only (scheme base) read-bytevector write-bytevector)
+          (only (scheme base) read-bytevector write-bytevector
+            input-port-open? output-port-open?)
           (only (chibi test) test-begin test test-end))
   (begin
     (define (run-tests)
@@ -163,5 +164,31 @@
             (let ((t2 (file-position p)))
               (close-input-port p)
               (list t0 t1 t2)))))
+
+      (let ((str-in (open-input-string "example"))
+            (str-out (open-output-string)))
+        (test #t (feed-pipe str-in str-out #f #f))
+        (test #t (input-port-open? str-in))
+        (test #t (output-port-open? str-out))
+        (test "example" (get-output-string str-out)))
+
+      (let ((vec-in (open-input-bytevector #u8(0 1 2 9 42)))
+            (vec-out (open-output-bytevector)))
+        (test #t (feed-pipe vec-in vec-out #f #f))
+        (test #t (input-port-open? vec-in))
+        (test #t (output-port-open? vec-out))
+        (test #u8(0 1 2 9 42) (get-output-bytevector vec-out)))
+
+      (let ((str-in (open-input-string "example"))
+            (str-out (open-output-string)))
+        (feed-pipe str-in str-out #t #t)
+        (test #f (input-port-open? str-in))
+        (test #f (output-port-open? str-out)))
+
+      (let ((vec-in (open-input-bytevector #u8(1 2 3)))
+            (vec-out (open-output-bytevector)))
+        (feed-pipe vec-in vec-out #t #t)
+        (test #f (input-port-open? vec-in))
+        (test #f (output-port-open? vec-out)))
 
       (test-end))))

--- a/lib/chibi/io.sld
+++ b/lib/chibi/io.sld
@@ -14,7 +14,7 @@
           make-filtered-input-port string-count-chars
           open-input-bytevector open-output-bytevector get-output-bytevector
           string->utf8 utf8->string
-          write-string write-u8 read-u8 peek-u8 send-file
+          write-string write-u8 read-u8 peek-u8 send-file feed-pipe
           is-a-socket?
           call-with-input-file call-with-output-file)
   (import (chibi) (chibi ast))

--- a/lib/chibi/io/io.stub
+++ b/lib/chibi/io/io.stub
@@ -62,3 +62,25 @@
   ((value ctx sexp) (value self sexp) (default (current-input-port) sexp)))
 (define-c sexp (peek-u8 "sexp_peek_u8")
   ((value ctx sexp) (value self sexp) (default (current-input-port) sexp)))
+
+;;> \procedure{(feed-pipe from to close-from close-to)}
+;;>
+;;> Feeds data between two \italic{pipe-like} ports (\var{from} and
+;;> \var{to}) until one of them is going to be blocked.
+;;>
+;;> The ports are assumed to be non-blocking; i.e., they must be either
+;;> 'virtual ports' opened by procedures like \scheme{open-input-string},
+;;> or the actual files opened in non-blocking mode.
+;;>
+;;> \scheme{#t} is returned if \var{from} was exhausted; i.e., the input
+;;> pipe was closed and no more data can be transferred between the pipes
+;;> at all. \scheme{#f} is returned if either of the pipes is going to be
+;;> blocked; i.e., no more data is currently available in \var{from}, or
+;;> \var{to} cannot accept any more data at the moment.
+;;>
+;;> Boolean arguments \var{close-from} and \var{close-to} control whether
+;;> the respective ports should be closed when the transfer is complete
+;;> (i.e., when \scheme{#t} is returned).
+
+(define-c sexp (feed-pipe "sexp_feed_pipe")
+  ((value ctx sexp) (value self exp) sexp sexp sexp sexp))

--- a/lib/chibi/process.sld
+++ b/lib/chibi/process.sld
@@ -14,10 +14,10 @@
           signal/user2      signal/child       signal/continue
           signal/stop       signal/tty-stop    signal/tty-input
           signal/tty-output wait/no-hang
-          call-with-process-io
+          call-with-process-io process-pipe
           process->string process->sexp process->string-list
           process->output+error process->output+error+status)
-  (import (chibi) (chibi io) (chibi string) (chibi filesystem))
-  (cond-expand (threads (import (srfi 18) (srfi 33))) (else #f))
+  (import (chibi) (chibi io) (chibi string) (chibi filesystem) (srfi 33))
+  (cond-expand (threads (import (srfi 18))) (else #f))
   (include-shared "process")
   (include "process.scm"))

--- a/lib/chibi/zlib.scm
+++ b/lib/chibi/zlib.scm
@@ -14,15 +14,10 @@
 ;; Utility to filter a bytevector to a process and return the
 ;; accumulated output as a new bytevector.
 (define (process-pipe-bytevector cmd bvec)
-  (call-with-process-io
-   cmd
-   (lambda (pid proc-in proc-out proc-err)
-     ;; This could overflow the pipe.
-     (write-bytevector bvec proc-in)
-     (close-output-port proc-in)
-     (let ((res (port->bytevector proc-out)))
-       (waitpid pid 0)
-       res))))
+  (let ((input (open-input-bytevector bvec))
+        (output (open-output-bytevector)))
+    (process-pipe cmd input output #f)
+    (get-output-bytevector output)))
 
 ;;> Gzip compress a string or bytevector in memory.
 

--- a/sexp.c
+++ b/sexp.c
@@ -1505,12 +1505,11 @@ int sexp_buffered_read_char (sexp ctx, sexp p) {
 }
 
 int sexp_buffered_write_char (sexp ctx, int c, sexp p) {
-  int res;
   if (sexp_port_offset(p)+1 >= sexp_port_size(p))
-    if ((res = sexp_buffered_flush(ctx, p, 0)))
-      return res;
+    if (sexp_buffered_flush(ctx, p, 0))
+      return EOF;
   sexp_port_buf(p)[sexp_port_offset(p)++] = c;
-  return 0;
+  return c;
 }
 
 int sexp_buffered_write_string_n (sexp ctx, const char *str,


### PR DESCRIPTION
This resolves issue #253 (at least [for me](https://travis-ci.org/ilammy/srfi-60/builds/57714289)).

The thing with pipes is that one cannot just write() stuff into it and go away. The trick is to read data fast enough from the read end to be able to write it fast enough into the write end. However, in this case we failed at it and got a deadlock. Chibi has filled gzip's input pipe with compressed data and is blocked in `write-u8` call waiting for gzip to read it. gzip has filled its output pipe with uncompressed data and is blocked in `write()` call waiting for Chibi to read it. A classical deadlock.

Chibi does not seem to provide Scheme procedures for non-blocking IO, so I wrote a utility `feed-pipe` to do pipe transfers properly. It does not block and allows to switch activity when the pipe buffer is full. This resolves the deadlock. If Chibi is going to be blocked on a write into gzip's input pipe, it instead will go and read something from its output pipe, which will unblock gzip, unclog the pipe, and eventually Chibi will be able to write without blocking. The same goes for the read end case.

`feed-pipe` is kinda low-level in that it assumes that the ports are actually _pipe-like_, but it does not check this and fails catastrophically (by deadlocking) if it is not true. So I have wrapped it into more easy-to-use `process-pipe` procedure that runs an arbitrary process using Scheme ports to pipe input and output.

The only bad thing is that `process-pipe` is busy-waiting if the forked process is not cooperating: e.g., leaves its output pipe open without writing anything into it, or does not read what we write into its input pipe. Currently, I do not have ideas on how to fix this. The _proper way_ would be to either use some kind of a select() to peek on pipes, or to spawn two threads for pumping data in and out then just join them.

Also I have fixed an inconsistency in `sexp_write_char()` macro which could return incorrect values sometimes. Well, most of the time its return value is simply ignored, but there are two cases where it isn't: `write-char` ([ASCII](https://github.com/ashinn/chibi-scheme/blob/4dda9230813fb8b26a5825225000f3a718cedd7c/vm.c#L1941-L1942) and [UTF-8](https://github.com/ashinn/chibi-scheme/blob/4dda9230813fb8b26a5825225000f3a718cedd7c/sexp.c#L2287-L2288)) and `write-u8` ([link](https://github.com/ashinn/chibi-scheme/blob/449feb88d3296fb5f41693fd705a2453592b133a/lib/chibi/io/port.c#L356)). And it is expected to have putc() interface there.

P.S. I have read the comment in zlib.scm saying that it should be rewritten in Scheme and avoid piping, but I believe `process-pipe` will be useful anyway.