### PR TITLE
Correction to the 8-10th selector aliases in SRFI-1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ install: all
 	$(INSTALL) -m0755 libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/
 	$(LN) -s -f libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/libchibi-scheme$(SO_MAJOR_VERSIONED_SUFFIX)
 	$(LN) -s -f libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/libchibi-scheme$(SO)
-	-$(INSTALL) -m0644 libchibi-scheme.a $(DESTDIR)$(SOLIBDIR)/
+	-if test -f libchibi-scheme.a; then $(INSTALL) -m0644 libchibi-scheme.a $(DESTDIR)$(SOLIBDIR)/; fi
 	$(MKDIR) $(DESTDIR)$(SOLIBDIR)/pkgconfig
 	$(INSTALL) -m0644 chibi-scheme.pc $(DESTDIR)$(SOLIBDIR)/pkgconfig/
 	$(MKDIR) $(DESTDIR)$(MANDIR)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Chibi-Scheme
+
+Minimal Scheme Implementation for use as an Extension Language
+
+http://synthcode.com/wiki/chibi-scheme
+
+Chibi-Scheme is a very small library intended for use as an extension
+and scripting language in C programs.  In addition to support for
+lightweight VM-based threads, each VM itself runs in an isolated heap
+allowing multiple VMs to run simultaneously in different OS threads.
+
+The default repl language contains all bindings from [R7RS small](http://trac.sacrideo.us/wg/wiki/R7RSHomePage),
+available explicitly as the `(scheme small)` library.
+
+Support for additional languages such as JavaScript, Go, Lua and Bash
+are planned for future releases.  Scheme is chosen as a substrate
+because its first class continuations and guaranteed tail-call
+optimization makes implementing other languages easy.
+
+To build on most platforms just run `make && make test`.  This will
+provide a shared library *"libchibi-scheme"*, as well as a sample
+*"chibi-scheme"* command-line repl.  You can then run `sudo make install`
+to install the binaries and libraries.  You can optionally specify a
+**PREFIX** for the installation directory:
+
+    make PREFIX=/path/to/install/
+    sudo make PREFIX=/path/to/install/ install
+
+By default files are installed in **/usr/local**.
+
+If you want to try out chibi-scheme without installing, be sure to set
+`LD_LIBRARY_PATH` so it can find the shared libraries.
+
+For more detailed documentation, run `make doc` and see the generated
+*"doc/chibi.html"*.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ![Chibi-Scheme](https://cloud.githubusercontent.com/assets/12776075/8023068/e6204a26-0cf9-11e5-9751-edc07ad2a8b5.png)
+# ![Chibi-Scheme](https://goo.gl/ZDtn4q)
 
-Minimal Scheme Implementation for use as an Extension Language
+**Minimal Scheme Implementation for use as an Extension Language**
 
 http://synthcode.com/wiki/chibi-scheme
 
@@ -19,7 +19,8 @@ because its first class continuations and guaranteed tail-call
 optimization makes implementing other languages easy.
 
 Chibi-Scheme is known to work on **32** and **64-bit** Linux,
-FreeBSD and OS X, Plan9, Windows (using Cygwin), iOS, and Emscripten.
+FreeBSD and OS X, Plan9, Windows (using Cygwin), iOS, and
+[Emscripten](https://kripken.github.io/emscripten-site).
 
 To build on most platforms just run `make && make test`.  This will
 provide a shared library *libchibi-scheme*, as well as a sample

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chibi-Scheme
+# ![Chibi-Scheme](http://synthcode.com/images/chibi-scheme-med.png)
 
 Minimal Scheme Implementation for use as an Extension Language
 
@@ -9,7 +9,8 @@ and scripting language in C programs.  In addition to support for
 lightweight VM-based threads, each VM itself runs in an isolated heap
 allowing multiple VMs to run simultaneously in different OS threads.
 
-The default repl language contains all bindings from [R7RS small](http://trac.sacrideo.us/wg/wiki/R7RSHomePage),
+The default repl language contains all bindings from
+[R7RS small](http://trac.sacrideo.us/wg/wiki/R7RSHomePage),
 available explicitly as the `(scheme small)` library.
 
 Support for additional languages such as JavaScript, Go, Lua and Bash
@@ -18,8 +19,11 @@ because its first class continuations and guaranteed tail-call
 optimization makes implementing other languages easy.
 
 To build on most platforms just run `make && make test`.  This will
-provide a shared library *"libchibi-scheme"*, as well as a sample
-*"chibi-scheme"* command-line repl.  You can then run `sudo make install`
+provide a shared library *libchibi-scheme*, as well as a sample
+*chibi-scheme* command-line repl.  You can then run
+
+    sudo make install
+
 to install the binaries and libraries.  You can optionally specify a
 **PREFIX** for the installation directory:
 
@@ -32,4 +36,4 @@ If you want to try out chibi-scheme without installing, be sure to set
 `LD_LIBRARY_PATH` so it can find the shared libraries.
 
 For more detailed documentation, run `make doc` and see the generated
-*"doc/chibi.html"*.
+*doc/chibi.html*.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![Chibi-Scheme](http://synthcode.com/images/chibi-scheme-med.png)
+# ![Chibi-Scheme](https://cloud.githubusercontent.com/assets/12776075/8023068/e6204a26-0cf9-11e5-9751-edc07ad2a8b5.png)
 
 Minimal Scheme Implementation for use as an Extension Language
 
@@ -17,6 +17,9 @@ Support for additional languages such as JavaScript, Go, Lua and Bash
 are planned for future releases.  Scheme is chosen as a substrate
 because its first class continuations and guaranteed tail-call
 optimization makes implementing other languages easy.
+
+Chibi-Scheme is known to work on **32** and **64-bit** Linux,
+FreeBSD and OS X, Plan9, Windows (using Cygwin), iOS, and Emscripten.
 
 To build on most platforms just run `make && make test`.  This will
 provide a shared library *libchibi-scheme*, as well as a sample

--- a/lib/srfi/1/selectors.scm
+++ b/lib/srfi/1/selectors.scm
@@ -9,9 +9,9 @@
 (define (fifth ls)   (car (cdr (cdr (cdr (cdr ls))))))
 (define (sixth ls)   (car (cdr (cdr (cdr (cdr (cdr ls)))))))
 (define (seventh ls) (car (cdr (cdr (cdr (cdr (cdr (cdr ls))))))))
-(define (eighth ls)  (car (cdr (cdr (cdr (cdr (cdr (cdr ls))))))))
-(define (ninth ls)   (car (cdr (cdr (cdr (cdr (cdr (cdr (cdr ls)))))))))
-(define (tenth ls)   (car (cdr (cdr (cdr (cdr (cdr (cdr (cdr (cdr ls))))))))))
+(define (eighth ls)  (car (cdr (cdr (cdr (cdr (cdr (cdr (cdr ls)))))))))
+(define (ninth ls)   (car (cdr (cdr (cdr (cdr (cdr (cdr (cdr (cdr ls))))))))))
+(define (tenth ls)   (car (cdr (cdr (cdr (cdr (cdr (cdr (cdr (cdr (cdr ls)))))))))))
 
 (define (car+cdr x) (values (car x) (cdr x)))
 


### PR DESCRIPTION
Correction to SRFI-1 *selectors.scm* :
The three selector aliases `eighth`, `ninth` and `tenth` were off by one *cdr*.