### PR TITLE
Revert usage of SRFI 60 in Chibi's libraries

### DIFF
--- a/lib/chibi/binary-record.sld
+++ b/lib/chibi/binary-record.sld
@@ -1,11 +1,8 @@
 
 (define-library (chibi binary-record)
   (import (scheme base)
-          (srfi 1) (srfi 9)
+          (srfi 1) (srfi 9) (srfi 33)
           (chibi io) (chibi string)
           (only (chibi) identifier? er-macro-transformer))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
   (export define-binary-record-type)
   (include "binary-record.scm"))

--- a/lib/chibi/bytevector.sld
+++ b/lib/chibi/bytevector.sld
@@ -9,8 +9,5 @@
    integer->bytevector bytevector->integer
    integer->hex-string hex-string->integer
    bytevector->hex-string hex-string->bytevector)
-  (import (scheme base))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
+  (import (scheme base) (srfi 33))
   (include "bytevector.scm"))

--- a/lib/chibi/crypto/md5.sld
+++ b/lib/chibi/crypto/md5.sld
@@ -3,9 +3,6 @@
 ;;> new applications SHA-2 should be preferred.
 
 (define-library (chibi crypto md5)
-  (import (scheme base) (chibi bytevector))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
+  (import (scheme base) (srfi 33) (chibi bytevector))
   (export md5)
   (include "md5.scm"))

--- a/lib/chibi/crypto/rsa.sld
+++ b/lib/chibi/crypto/rsa.sld
@@ -2,11 +2,8 @@
 ;;> RSA public key cryptography implementation.
 
 (define-library (chibi crypto rsa)
-  (import (scheme base) (srfi 27)
+  (import (scheme base) (srfi 27) (srfi 33)
           (chibi bytevector) (chibi math prime))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
   (export make-rsa-key rsa-key-gen rsa-key-gen-from-primes rsa-pub-key
           rsa-encrypt rsa-decrypt rsa-sign rsa-verify rsa-verify?
           rsa-key? rsa-key-bits rsa-key-n rsa-key-e rsa-key-d

--- a/lib/chibi/crypto/sha2.sld
+++ b/lib/chibi/crypto/sha2.sld
@@ -10,10 +10,7 @@
     (include "sha2-native.scm")
     (include-shared "crypto"))
    (else
-    (cond-expand
-     ((library (srfi 60)) (import (srfi 60)))
-     (else (import (srfi 33))))
-    (import (chibi bytevector))
+    (import (srfi 33) (chibi bytevector))
     (include "sha2.scm"))))
 
 ;;> \procedure{(sha-224 src)}

--- a/lib/chibi/iset/base.sld
+++ b/lib/chibi/iset/base.sld
@@ -3,9 +3,7 @@
   (cond-expand
    (chibi (import (chibi) (srfi 9)))
    (else (import (scheme base))))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
+  (import (srfi 33))
   (include "base.scm")
   (export
    %make-iset make-iset iset? iset-contains? Integer-Set

--- a/lib/chibi/iset/constructors.sld
+++ b/lib/chibi/iset/constructors.sld
@@ -3,10 +3,7 @@
   (cond-expand
    (chibi (import (chibi)))
    (else (import (scheme base))))
-  (import (chibi iset base) (chibi iset iterators))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
+  (import (srfi 33) (chibi iset base) (chibi iset iterators))
   (include "constructors.scm")
   (export
    iset iset-copy list->iset list->iset! iset-map

--- a/lib/chibi/iset/iterators.sld
+++ b/lib/chibi/iset/iterators.sld
@@ -3,10 +3,7 @@
   (cond-expand
    (chibi (import (chibi) (srfi 9)))
    (else (import (scheme base))))
-  (import (chibi iset base))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
+  (import (srfi 33) (chibi iset base))
   (include "iterators.scm")
   (export
    iset-empty? iset-fold iset-fold-node iset-for-each iset-for-each-node

--- a/lib/chibi/iset/optimize.sld
+++ b/lib/chibi/iset/optimize.sld
@@ -3,17 +3,10 @@
   (cond-expand
    (chibi (import (chibi) (srfi 9)))
    (else (import (scheme base))))
-  (import (chibi iset base)
+  (import (srfi 33)
+          (chibi iset base)
           (chibi iset iterators)
           (chibi iset constructors))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else
-    (import (srfi 33))
-    (begin
-      (define (%mask size) (bitwise-not (arithmetic-shift -1 size)))
-      (define (extract-bit-field size position n)
-        (bitwise-and (%mask size) (arithmetic-shift n (- position)))))))
   (include "optimize.scm")
   (export
    iset-balance iset-balance! iset-optimize iset-optimize! iset->code))

--- a/lib/chibi/math/prime.sld
+++ b/lib/chibi/math/prime.sld
@@ -1,9 +1,6 @@
 
 (define-library (chibi math prime)
-  (import (scheme base) (scheme inexact) (srfi 27))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
+  (import (scheme base) (scheme inexact) (srfi 27) (srfi 33))
   (export prime? nth-prime prime-above prime-below factor perfect?
           totient aliquot
           provable-prime? probable-prime?

--- a/lib/chibi/regexp.sld
+++ b/lib/chibi/regexp.sld
@@ -11,10 +11,7 @@
           regexp-match-submatch regexp-match-submatch/list
           regexp-match-submatch-start regexp-match-submatch-end
           regexp-match->list regexp-match->sexp)
-  (import (srfi 69))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
+  (import (srfi 33) (srfi 69))
   ;; Chibi's char-set library is more factored than SRFI-14.
   (cond-expand
    (chibi

--- a/lib/chibi/regexp/pcre.sld
+++ b/lib/chibi/regexp/pcre.sld
@@ -2,9 +2,6 @@
 (define-library (chibi regexp pcre)
   (export pcre->sre pcre->regexp)
   (import (scheme base) (scheme char) (scheme cxr)
-          (srfi 1)
+          (srfi 1) (srfi 33)
           (chibi string) (chibi regexp))
-  (cond-expand
-   ((library (srfi 60)) (import (srfi 60)))
-   (else (import (srfi 33))))
   (include "pcre.scm"))


### PR DESCRIPTION
This partially reverts commit 00691b64f11225802b787b0920377c1f0fe29b10, removing the dependency on external SRFI 60 which may cause dependency cycles and entirely prevent Chibi from loading libraries.

----

Resolves issue #267