### PR TITLE
Integrate emscripten build process in Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Object files
 *.o
+*.bc
 *.ko
 *.obj
 *.elf
@@ -36,6 +37,7 @@ lib/.*.meta
 
 # Generated files
 chibi-scheme
+chibi-scheme-emscripten
 chibi-scheme.pc
 include/chibi/install.h
 lib/chibi/emscripten.c
@@ -48,6 +50,7 @@ lib/chibi/system.c
 lib/chibi/time.c
 *.tgz
 *.html
+!index.html
 
 examples/snow-fort
 examples/synthcode
@@ -58,3 +61,6 @@ tmp
 /lib/chibi/crypto/crypto.c
 /chibi-scheme-ulimit
 /clibs.c
+
+js/chibi.*
+

--- a/js/exported_functions.json
+++ b/js/exported_functions.json
@@ -1,0 +1,5 @@
+[
+  '_main',
+  '_sexp_resume'
+]
+

--- a/js/index.html
+++ b/js/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Chibi-Scheme</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        height: 100vh;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+      }
+      main {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+      #program {
+        flex: 1 1 0;
+        padding: 0.5em;
+      }
+      #start {
+        font-size: inherit;
+        padding: 0.5em;
+      }
+      #output {
+        font-family: monospace;
+        padding: 0.5em;
+        white-space: pre;
+        background-color: #000;
+        color: #fff;
+        overflow: auto;
+        flex: 1 1 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <textarea id="program" spellcheck="false">;
+; This is Chibi-Scheme compiled with Emscripten to run in the browser.
+;
+
+(import (scheme base))
+(write-string "Hello, world!\n")
+
+;
+; You can also run arbitrary JavaScript code from scheme and yield control back and forth between Scheme and the browser
+;
+
+(import (chibi emscripten)) ; exports: eval-script!, integer-eval-script, string-eval-script, wait-on-event!
+
+(write-string (number->string (integer-eval-script "6 * 7")))
+(newline)
+
+(eval-script! "window.addEventListener('click', function () {
+  Module['resume'](); // give control back to the Scheme process
+})")
+
+(let loop ()
+  (wait-on-event!) ; yields control back to the browser
+  (write-string "You have clicked me!\n")
+  (loop))
+
+(write-string "Control never reaches this point\n")
+</textarea>
+      <button type="button" id="start" disabled>Start Program</button>
+      <div id="output"></div>
+    </main>
+    <script src="chibi.js"></script>
+    <script>
+      function start(program, args, onOutput, onError) {
+        var firstError = true;
+        Chibi({
+          print: onOutput,
+          printErr: function (text) {
+            if (firstError) {
+              firstError = false;
+              return;
+            }
+            if (onError !== undefined) {
+              onError(text);
+            } else {
+              onOutput(text);
+            }
+          },
+          program: program,
+          arguments: args
+        });
+      }
+    </script>
+    <script>
+      (function () {
+        var programField = document.querySelector('#program');
+        var startButton = document.querySelector('#start');
+        var program = sessionStorage.getItem('program');
+        if (program) {
+          programField.value = program;
+        }
+        programField.addEventListener('input', function() {
+          sessionStorage.setItem('program', programField.value);
+        });
+        startButton.addEventListener('click', function() {
+          var program = programField.value;
+          startButton.disabled = true;
+          start(program, [],
+              function(text) {
+                output.textContent = output.textContent + text + '\n'
+              });
+        });
+        startButton.disabled = false;
+      })();
+    </script>
+  </body>
+</html>

--- a/js/post.js
+++ b/js/post.js
@@ -1,0 +1,2 @@
+Module['resume'] = Module.cwrap('sexp_resume', 'void', []);
+

--- a/js/pre.js
+++ b/js/pre.js
@@ -1,0 +1,6 @@
+Module['preRun'].push(function () {
+  FS.writeFile('program.scm', Module['program']);
+});
+Module['arguments'] = Module['arguments'] || [];
+Module['arguments'].unshift('program.scm');
+


### PR DESCRIPTION
This is an attempt to integrate the build process for the Emscripten output into the regular Makefile of Chibi Scheme. (So far, external scripts have been provided through https://github.com/mnieper/chibi-scheme.js).

If a recent enough version of Emscripten is installed, `make chibi.js` will first build a static executable under the host system (which is being renamed to `chibi-scheme-emscripten`), which in turn is used to compile object files with the Emscripten tool chain.

Afterwards, navigating to `index.html` shows a little demo page.