### PR TITLE
Fix dynamic linking on Linux when installed outside of the current linker path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ libchibi-scheme.a: $(SEXP_OBJS) $(EVAL_OBJS)
 	$(AR) rcs $@ $^
 
 chibi-scheme$(EXE): main.o libchibi-scheme$(SO)
-	$(CC) $(XCPPFLAGS) $(XCFLAGS) $(LDFLAGS) -o $@ $< -L. -lchibi-scheme
+	$(CC) $(XCPPFLAGS) $(XCFLAGS) -o $@ $< -L. -lchibi-scheme $(XLDFLAGS)
 
 chibi-scheme-static$(EXE): main.o $(SEXP_OBJS) $(EVAL_OBJS)
 	$(CC) $(XCFLAGS) $(STATICFLAGS) -o $@ $^ $(LDFLAGS) $(GCLDFLAGS) -lm
@@ -159,7 +159,7 @@ chibi-scheme.pc: chibi-scheme.pc.in
 # A special case, this needs to be linked with the LDFLAGS in case
 # we're using Boehm.
 lib/chibi/ast$(SO): lib/chibi/ast.c $(INCLUDES) libchibi-scheme$(SO)
-	-$(CC) $(CLIBFLAGS) $(CLINKFLAGS) $(XCPPFLAGS) $(XCFLAGS) $(LDFLAGS) -o $@ $< $(GCLDFLAGS) -L. -lchibi-scheme
+	-$(CC) $(CLIBFLAGS) $(CLINKFLAGS) $(XCPPFLAGS) $(XCFLAGS) -o $@ $< -L. -lchibi-scheme $(XLDFLAGS)
 
 doc: doc/chibi.html doc-libs
 

--- a/Makefile.detect
+++ b/Makefile.detect
@@ -65,6 +65,7 @@ EXE =
 CLIBFLAGS = -fPIC
 CLINKFLAGS = -shared
 LIBDL = 
+RLDFLAGS=-Wl,-R$(DESTDIR)$(LIBDIR)
 else
 ifeq ($(PLATFORM),mingw)
 SO  = .dll
@@ -92,19 +93,12 @@ CLIBFLAGS = -fPIC
 CLINKFLAGS = -shared
 STATICFLAGS = -static -DSEXP_USE_DL=0
 LIBCHIBI_FLAGS = -Wl,-soname,libchibi-scheme$(SO).$(SOVERSION_MAJOR)
-ifeq ($(PLATFORM),BSD)
-LIBDL=
-RLDFLAGS=-Wl,-R$(DESTDIR)$(LIBDIR)
-endif
-endif
-endif
-endif
-endif
-endif
-
-ifeq ($(PLATFORM),unix)
 #RLDFLAGS=-rpath $(LIBDIR)
 RLDFLAGS=-Wl,-R$(DESTDIR)$(LIBDIR)
+endif
+endif
+endif
+endif
 endif
 
 ########################################################################

--- a/Makefile.libs
+++ b/Makefile.libs
@@ -49,7 +49,7 @@ lib/%.c: lib/%.stub $(CHIBI_FFI_DEPENDENCIES)
 	$(CHIBI_FFI) $<
 
 lib/%$(SO): lib/%.c $(INCLUDES) libchibi-scheme$(SO)
-	$(CC) $(CLIBFLAGS) $(CLINKFLAGS) $(XCPPFLAGS) $(XCFLAGS) $(LDFLAGS) -o $@ $< -L. $(XLIBS) -lchibi-scheme
+	$(CC) $(CLIBFLAGS) $(CLINKFLAGS) $(XCPPFLAGS) $(XCFLAGS) -o $@ $< -L. $(XLIBS) -lchibi-scheme $(LDFLAGS) $(RLDFLAGS) $(LIBDL)
 
 doc-libs: $(HTML_LIBS)
 


### PR DESCRIPTION
Adds rpath when dynamically linking the interpreter and shared libraries.
