### PR TITLE
Allow asin and acos to return an exact zero result in the R7RS tests

### DIFF
--- a/tests/r7rs-tests.scm
+++ b/tests/r7rs-tests.scm
@@ -836,9 +836,9 @@
 (test 0.0 (inexact (tan 0))) ;; may return exact number
 (test 1.5574077246549 (tan 1))
 
-(test 0.0 (asin 0))
+(test 0.0 (inexact (asin 0))) ;; may return exact number
 (test 1.5707963267949 (asin 1))
-(test 0.0 (acos 1))
+(test 0.0 (inexact (acos 1))) ;; may return exact number
 (test 3.14159265358979 (acos -1))
 
 (test 0.0 (atan 0.0 1.0))


### PR DESCRIPTION
Racket returns exact numbers for `(asin 0)` and `(acos 1)`, and the spec doesn't appear to comment on the exactness of the result of these functions.