### PR TITLE
Remove unnecessary variable referencing

### DIFF
--- a/Makefile.detect
+++ b/Makefile.detect
@@ -110,7 +110,7 @@ endif
 ########################################################################
 # Check for headers (who needs autoconf?)
 
-ifndef $(SEXP_USE_NTP_GETTIME)
+ifndef SEXP_USE_NTP_GETTIME
 SEXP_USE_NTP_GETTIME := $(shell echo "main(){struct ntptimeval n; ntp_gettime(&n);}" | gcc -fsyntax-only -include sys/timex.h -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
 endif
 
@@ -118,7 +118,7 @@ ifeq ($(SEXP_USE_NTP_GETTIME),1)
 CPPFLAGS += -DSEXP_USE_NTPGETTIME
 endif
 
-ifndef $(SEXP_USE_INTTYPES)
+ifndef SEXP_USE_INTTYPES
 SEXP_USE_INTTYPES := $(shell echo "main(){int_least8_t x;}" | gcc -fsyntax-only -include inttypes.h -xc - >/dev/null 2>/dev/null && echo 1 || echo 0)
 endif
 


### PR DESCRIPTION
Those variables are now correctly detected when defined in the parent makefile.

---
Hello Alex,

I'm working on a simple makefile to cleanly build Chibi-Scheme with the MinGW-W64 toolchain (distributed by Stephan T. Lavavej at http://nuwen.net/mingw.html) on Windows 10.

The shared library and the interpreter are done (with a few warnings on type boundaries), and I'm now looking into the module system. Windows isn't keen on providing the required threads, sockets and system calls. I'll see what is possible to port over with the Windows standard libraries, and maybe with a cross-platform solution like libuv (http://github.com/libuv/libuv).

- Frère Jérôme