### PR TITLE
Patch-1 for MinGW

### DIFF
--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -739,6 +739,10 @@
 #define isinf(x) (isInf(x,1) || isInf(x,-1))
 #define isnan(x) isNaN(x)
 #elif defined(_WIN32)
+#ifdef __MINGW32__
+#include <shlwapi.h>
+#define strcasestr StrStrI
+#else
 #define snprintf(buf, len, fmt, val) sprintf(buf, fmt, val)
 #define strcasecmp lstrcmpi
 #define strncasecmp(s1, s2, n) lstrcmpi(s1, s2)
@@ -746,6 +750,7 @@
 #define trunc(x) floor((x)+0.5*(((x)<0)?1:0))
 #define isnan(x) (x!=x)
 #define isinf(x) (x > DBL_MAX || x < -DBL_MAX)
+#endif
 #endif
 
 #ifdef _WIN32

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -65,7 +65,9 @@ typedef unsigned long size_t;
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#if !(defined _WIN32) || defined(__CYGWIN__)
 #include <sys/socket.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <math.h>


### PR DESCRIPTION
MinGW 32 & 64 provide `snprintf()`, `str[n]casecmp()` and common math functions.
Only the GNU-specific `strcasestr()` is missing, handled here by `StrStrI`.
Exclude the *POSIX* `socket.h` for this platform.