### PR TITLE
Patch-2 for MinGW

### DIFF
--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -690,7 +690,7 @@ SEXP_API sexp sexp_make_flonum(sexp ctx, float f);
 #define sexp_flonump(x)      (sexp_check_tag(x, SEXP_FLONUM))
 #define sexp_flonum_value(f) ((f)->value.flonum)
 #define sexp_flonum_bits(f) ((f)->value.flonum_bits)
-sexp sexp_make_flonum(sexp ctx, double f);
+SEXP_API sexp sexp_make_flonum(sexp ctx, double f);
 #endif
 
 #define sexp_typep(x)       (sexp_check_tag(x, SEXP_TYPE))

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -21,6 +21,13 @@ extern "C" {
 #define sexp_isdigit(x) ((isdigit)((int)(x)))
 #define sexp_tolower(x) ((tolower)((int)(x)))
 #define sexp_toupper(x) ((toupper)((int)(x)))
+#if SEXP_USE_DL
+#define RTLD_DEFAULT 0
+#define RTLD_LAZY    0
+#define dlopen(lib,mode) (void*)LoadLibrary(lib)
+#define dlsym(lib,sym) (void*)GetProcAddress((HMODULE)lib,sym)
+#define dlclose(lib) (int)FreeLibrary((HMODULE)lib)
+#endif
 #else
 #if SEXP_USE_DL
 #include <dlfcn.h>

--- a/lib/chibi/ast.c
+++ b/lib/chibi/ast.c
@@ -8,6 +8,11 @@
 #include <errno.h>
 #endif
 
+#if defined(_WIN32) || defined(__MINGW32__)
+#define setenv(name,value,override) SetEnvironmentVariable(name,value)
+#define unsetenv(name) SetEnvironmentVariable(name,NULL)
+#endif
+
 #if ! SEXP_USE_BOEHM
 extern sexp sexp_gc (sexp ctx, size_t *sum_freed);
 #endif
@@ -429,11 +434,11 @@ static sexp sexp_set_atomic (sexp ctx, sexp self, sexp_sint_t n, sexp new_val) {
 #endif
 
 sexp sexp_thread_list (sexp ctx, sexp self, sexp_sint_t n) {
-  sexp ls;
   sexp_gc_var1(res);
   sexp_gc_preserve1(ctx, res);
   res = SEXP_NULL;
 #if SEXP_USE_GREEN_THREADS
+  sexp ls;
   for (ls=sexp_global(ctx, SEXP_G_THREADS_FRONT); sexp_pairp(ls); ls=sexp_cdr(ls))
     sexp_push(ctx, res, sexp_car(ls));
   for (ls=sexp_global(ctx, SEXP_G_THREADS_PAUSED); sexp_pairp(ls); ls=sexp_cdr(ls))
@@ -530,7 +535,7 @@ static sexp sexp_abort (sexp ctx, sexp self, sexp_sint_t n, sexp value) {
 #define sexp_define_type(ctx, name, tag) \
   sexp_env_define(ctx, env, sexp_intern(ctx, name, -1), sexp_type_by_index(ctx, tag));
 
-sexp sexp_init_library (sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version, const sexp_abi_identifier_t abi) {
+SEXP_API sexp sexp_init_library (sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version, const sexp_abi_identifier_t abi) {
   if (!(sexp_version_compatible(ctx, version, sexp_version)
         && sexp_abi_compatible(ctx, abi, SEXP_ABI_IDENTIFIER)))
     return SEXP_ABI_ERROR;

--- a/lib/scheme/time.c
+++ b/lib/scheme/time.c
@@ -93,7 +93,7 @@ static sexp sexp_current_clock_second (sexp ctx, sexp self, sexp_sint_t n) {
 #endif
 }
 
-sexp sexp_init_library (sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version, const sexp_abi_identifier_t abi) {
+SEXP_API sexp sexp_init_library (sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version, const sexp_abi_identifier_t abi) {
   if (!(sexp_version_compatible(ctx, version, sexp_version)
         && sexp_abi_compatible(ctx, abi, SEXP_ABI_IDENTIFIER)))
     return sexp_global(ctx, SEXP_G_ABI_ERROR);

--- a/tools/chibi-ffi
+++ b/tools/chibi-ffi
@@ -1962,7 +1962,7 @@
   (newline)
   (if *c++?*
       (cat "extern \"C\"\n"))
-  (cat "sexp sexp_init_library (sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version, const sexp_abi_identifier_t abi) {\n"
+  (cat "SEXP_API sexp sexp_init_library (sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version, const sexp_abi_identifier_t abi) {\n"
        (lambda ()
          (for-each
           (lambda (t) (cat "  sexp " t ";\n"))


### PR DESCRIPTION
Allows dynamic loading of libraries on Windows, provided that `sexp sexp_init_library()` is properly exported. Could `SEXP_API` be used in this case?
If so, it would be necessary to go through the tree and add this prefix to each library *C* file.