### PR TITLE
test/ffi: Complete removal of delete-file on shared object

### DIFF
--- a/tests/ffi/ffi-tests.scm
+++ b/tests/ffi/ffi-tests.scm
@@ -43,7 +43,6 @@
               ((= orig-failures (test-failure-count))
                (delete-file stub-file)
                (delete-file c-file)))
-             (delete-file lib-file)
              (trash-shared-object! lib-file)))
           (else
            (test-assert (string-append "couldn't compile " name)


### PR DESCRIPTION
Sorry but my previous branch was just incomplete.. Obviously, we have to remove this line to complete the change! I must forgot to `add` the file before pushing.

I have doubly-checked on Cygwin32/64 and CentOS7. Sorry again for oversight..