### PR TITLE
Exclude unsupported functions in Emscripten version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ bench-gabriel: chibi-scheme$(EXE)
 # Packaging
 
 clean: clean-libs
-	-$(RM) *.o *.i *.s *.8 tests/basic/*.out tests/basic/*.err \
+	-$(RM) *.o *.i *.s *.bc *.8 tests/basic/*.out tests/basic/*.err \
 	    tests/run/*.out tests/run/*.err
 
 cleaner: clean

--- a/lib/chibi/system.sld
+++ b/lib/chibi/system.sld
@@ -1,9 +1,9 @@
 
 (define-library (chibi system)
   (export get-host-name
-          user-information user? user-name user-password
+          user? user-name user-password
           user-id user-group-id user-gecos user-home user-shell
-          group-information group-name group-password group-id
+          group-name group-password group-id
           current-user-id current-group-id
           current-effective-user-id current-effective-group-id
           set-current-user-id! set-current-effective-user-id!

--- a/lib/chibi/system.sld
+++ b/lib/chibi/system.sld
@@ -12,12 +12,16 @@
           set-root-directory!)
   (import (chibi))
   (include-shared "system")
-  (body
-   (define (user-information user)
-     (car (if (string? user)
-              (getpwnam_r user (make-string 1024))
-              (getpwuid_r user (make-string 1024)))))
-   (define (group-information group)
-     (car (if (string? group)
-              (getgrnam_r group (make-string 1024))
-              (getgrgid_r group (make-string 1024)))))))
+  (cond-expand
+   (emscripten)
+   (else
+    (export user-information group-information)
+    (body
+     (define (user-information user)
+       (car (if (string? user)
+		(getpwnam_r user (make-string 1024))
+		(getpwuid_r user (make-string 1024)))))
+     (define (group-information group)
+       (car (if (string? group)
+		(getgrnam_r group (make-string 1024))
+		(getgrgid_r group (make-string 1024)))))))))


### PR DESCRIPTION
The ‘(chibi system)’ library uses some C functions that are currently not available in Emscripten compiled code so they have to be omitted when the target is ‘emscripten’.
