### PR TITLE
Modify makefiles to make LDCONFIG optional, support systems with no s…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,10 @@ libchibi-scheme$(SO_VERSIONED_SUFFIX): $(SEXP_OBJS) $(EVAL_OBJS)
 	$(CC) $(CLIBFLAGS) $(CLINKFLAGS) $(LIBCHIBI_FLAGS) -o $@ $^ $(XLDFLAGS)
 
 libchibi-scheme$(SO_MAJOR_VERSIONED_SUFFIX): libchibi-scheme$(SO_VERSIONED_SUFFIX)
-	$(LN) -sf $< $@
+	$(LN) $< $@
 
 libchibi-scheme$(SO): libchibi-scheme$(SO_MAJOR_VERSIONED_SUFFIX)
-	$(LN) -sf $< $@
+	$(LN) $< $@
 
 libchibi-scheme.a: $(SEXP_OBJS) $(EVAL_OBJS)
 	$(AR) rcs $@ $^
@@ -283,7 +283,9 @@ install: all
 	$(MKDIR) $(DESTDIR)$(MODDIR)/scheme/time
 	$(MKDIR) $(DESTDIR)$(MODDIR)/srfi/1 $(DESTDIR)$(MODDIR)/srfi/18 $(DESTDIR)$(MODDIR)/srfi/27 $(DESTDIR)$(MODDIR)/srfi/33 $(DESTDIR)$(MODDIR)/srfi/39 $(DESTDIR)$(MODDIR)/srfi/69 $(DESTDIR)$(MODDIR)/srfi/95 $(DESTDIR)$(MODDIR)/srfi/99 $(DESTDIR)$(MODDIR)/srfi/99/records
 	$(INSTALL) -m0644 $(META_FILES) $(DESTDIR)$(MODDIR)/
+ifneq "$(IMAGE_FILES)" ""
 	$(INSTALL) -m0644 $(IMAGE_FILES) $(DESTDIR)$(MODDIR)/
+endif
 	$(INSTALL) -m0644 lib/*.scm $(DESTDIR)$(MODDIR)/
 	$(INSTALL) -m0644 lib/chibi/*.sld lib/chibi/*.scm $(DESTDIR)$(MODDIR)/chibi/
 	$(INSTALL) -m0644 lib/chibi/char-set/*.sld lib/chibi/char-set/*.scm $(DESTDIR)$(MODDIR)/chibi/char-set/
@@ -336,8 +338,8 @@ install: all
 	$(MKDIR) $(DESTDIR)$(LIBDIR)
 	$(MKDIR) $(DESTDIR)$(SOLIBDIR)
 	$(INSTALL_EXE) -m0755 libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/
-	$(LN) -s -f libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/libchibi-scheme$(SO_MAJOR_VERSIONED_SUFFIX)
-	$(LN) -s -f libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/libchibi-scheme$(SO)
+	$(LN) libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/libchibi-scheme$(SO_MAJOR_VERSIONED_SUFFIX)
+	$(LN) libchibi-scheme$(SO_VERSIONED_SUFFIX) $(DESTDIR)$(SOLIBDIR)/libchibi-scheme$(SO)
 	-if test -f libchibi-scheme.a; then $(INSTALL) -m0644 libchibi-scheme.a $(DESTDIR)$(SOLIBDIR)/; fi
 	$(MKDIR) $(DESTDIR)$(PKGCONFDIR)
 	$(INSTALL) -m0644 chibi-scheme.pc $(DESTDIR)$(PKGCONFDIR)
@@ -345,7 +347,7 @@ install: all
 	$(INSTALL) -m0644 doc/chibi-scheme.1 $(DESTDIR)$(MANDIR)/
 	$(INSTALL) -m0644 doc/chibi-ffi.1 $(DESTDIR)$(MANDIR)/
 	$(INSTALL) -m0644 doc/chibi-doc.1 $(DESTDIR)$(MANDIR)/
-	-if type ldconfig >/dev/null 2>/dev/null; then ldconfig; fi
+	-if type $(LDCONFIG) >/dev/null 2>/dev/null; then $(LDCONFIG); fi
 
 uninstall:
 	-$(RM) $(DESTDIR)$(BINDIR)/chibi-scheme$(EXE)

--- a/Makefile.libs
+++ b/Makefile.libs
@@ -14,7 +14,7 @@ CD        ?= cd
 RM        ?= rm -f
 LS        ?= ls
 CP        ?= cp
-LN        ?= ln
+LN        ?= ln -sf
 INSTALL   ?= install
 INSTALL_EXE	?=	$(INSTALL)
 MKDIR     ?= $(INSTALL) -d
@@ -24,6 +24,7 @@ DIFF      ?= diff
 GREP      ?= grep
 FIND      ?= find
 SYMLINK   ?= ln -s
+LDCONFIG  ?= ldconfig
 
 PREFIX    ?= /usr/local
 BINDIR    ?= $(PREFIX)/bin


### PR DESCRIPTION
…ymlinks.

  - Makefile.libs: changed definition of LN to LN -sf, so can be overridden
    with LN=cp on systems with no symlinks; introduced LDCONFIG, so can be
    overridden if desired.

  - Makefile: changed uses of $(LN) -sf to $(LN); replaced two occurrences
    of ldconfig by $(LDCONFIG); suppress install of $(IMAGE_FILES) if variable
    is empty.

Note: the IMAGE_FILES change was to enable Chibi to be compiled on GNURoot+Android,
and can be reasonably reverted if an alternate way of dealing with image files
is chosen.