### PR TITLE
Add SRFI 124 interface to Chibi's ephemerons.

### DIFF
--- a/lib/srfi/124.sld
+++ b/lib/srfi/124.sld
@@ -1,0 +1,4 @@
+(define-library (srfi 124)
+  (export make-ephemeron ephemeron? ephemeron-broken?
+	  ephemeron-key ephemeron-datum)
+  (import (rename (chibi weak) (ephemeron-value ephemeron-datum))))


### PR DESCRIPTION
(Note that although Chibi's implementation of proper ephemerons is not
complete, it still counts as an implementation of SRFI 124, which even
allows a trivial implementation.)