### PR TITLE
fixed let(*)-values when no bindings are given

### DIFF
--- a/lib/srfi/11.sld
+++ b/lib/srfi/11.sld
@@ -6,7 +6,7 @@
    (define-syntax let*-values
      (syntax-rules ()
        ((let*-values () . body)
-        (begin . body))
+        (let () . body))
        ((let*-values (((a) expr) . rest) . body)
         (let ((a expr)) (let*-values rest . body)))
        ((let*-values ((params expr) . rest) . body)
@@ -14,6 +14,8 @@
           (lambda params (let*-values rest . body))))))
    (define-syntax let-values
      (syntax-rules ()
+       ((let-values () . body)
+	(let () . body))
        ((let-values ("step") (binds ...) bind expr maps () () . body)
         (let*-values (binds ... (bind expr)) (let maps . body)))
        ((let-values ("step") (binds ...) bind old-expr maps () ((params expr) . rest) . body)
@@ -23,5 +25,4 @@
        ((let-values ("step") binds (bind ...) expr (maps ...) x rest . body)
         (let-values ("step") binds (bind ... . tmp) expr (maps ... (x tmp)) () rest . body))
        ((let-values ((params expr) . rest) . body)
-        (let-values ("step") () () expr () params rest . body))
-       ))))
+        (let-values ("step") () () expr () params rest . body))))))

--- a/tests/r7rs-tests.scm
+++ b/tests/r7rs-tests.scm
@@ -237,6 +237,14 @@
                 ((x y) (values a b)))
     (list a b x y))))
 
+(test 'ok (let-values () 'ok))
+
+(test 1 (let ((x 1))
+	  (let*-values ()
+	    (define x 2)
+	    #f)
+	  x))
+
 (let ()
   (define x 0)
   (set! x 5)


### PR DESCRIPTION
Fixes two incompatibilities with R7RS:

- let*-values may introduce no bindings
- let-values with no bindings introduces a new scope
