### PR TITLE
Arranged definitions to prevent double definition

### DIFF
--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -761,10 +761,10 @@
 #define _CRT_SECURE_NO_WARNINGS 1
 #define _CRT_NONSTDC_NO_DEPRECATE 1
 #pragma warning(disable:4146) /* unary minus operator to unsigned type */
-#define strcasecmp lstrcmpi
-#define strncasecmp(s1, s2, n) lstrcmpi(s1, s2)
 #ifdef __MINGW32__
 #include <shlwapi.h>
+#define strcasecmp lstrcmpi
+#define strncasecmp(s1, s2, n) lstrcmpi(s1, s2)
 #define strcasestr StrStrI
 #define SHUT_RD 0
 #define SHUT_WR 1


### PR DESCRIPTION
- It is possible to define `strcasecmp` and
  `strncasecmp` twice if `__MINGW32__` is defined.
  However, the same definition is used if it's not.
  Therefore, I just moved it inside of the "if-defined"
  case. It removes the errors pertaining to that header.

- Additional compilation errors related to the filesystem
  implementation and POSIX definitions of constants still
  are brought up when compiling on Windows 10, MSYS2-mingw-w64
  with gcc.

- I am attaching an **error log** file that shows the additional errors when working on MSYS2's mingw-w64. It appears most of it is due to the use of POSIX stuff that MinGW-w64 may not support.

[mingw-w64-msys2-errorlog.txt](https://github.com/ashinn/chibi-scheme/files/820778/mingw-w64-msys2-errorlog.txt)
