### PR TITLE
Remove argv[0] from the arguments of main_symbol.

### DIFF
--- a/lib/chibi/net/http-server.scm
+++ b/lib/chibi/net/http-server.scm
@@ -522,4 +522,4 @@
       (verbose? boolean (#\v "verbose"))))
     ,run-app))
 
-(define (main args) (run-application app-spec args))
+(define (main args) (run-application app-spec))

--- a/lib/chibi/tar.scm
+++ b/lib/chibi/tar.scm
@@ -280,18 +280,17 @@
         res))))
 
 (define (main args)
-  (let ((args (cdr args)))
-    (cond
-     ((equal? "t" (car args))
-      (for-each (lambda (f) (write-string f) (newline)) (tar-files (cadr args))))
-     ((equal? "x" (car args))
-      (if (tar-safe? (cadr args))
-          (tar-extract (cadr args))
-          (error "tar file not a single relative directory" (cadr args))))
-     ((equal? "c" (car args))
-      (tar-create (cadr args) (cddr args)))
-     ((equal? "f" (car args))
-      (write-string
+  (cond
+    ((equal? "t" (car args))
+     (for-each (lambda (f) (write-string f) (newline)) (tar-files (cadr args))))
+    ((equal? "x" (car args))
+     (if (tar-safe? (cadr args))
+       (tar-extract (cadr args))
+       (error "tar file not a single relative directory" (cadr args))))
+    ((equal? "c" (car args))
+     (tar-create (cadr args) (cddr args)))
+    ((equal? "f" (car args))
+     (write-string
        (utf8->string (tar-extract-file (cadr args) (car (cddr args))))))
-     (else
-      (error "unknown tar command" (car args))))))
+    (else
+     (error "unknown tar command" (car args)))))

--- a/main.c
+++ b/main.c
@@ -597,7 +597,7 @@ sexp run_main (int argc, char **argv) {
         sym = sexp_intern(ctx, main_symbol, -1);
         tmp = sexp_env_ref(ctx, env, sym, SEXP_FALSE);
         if (sexp_procedurep(tmp)) {
-          args = sexp_list1(ctx, args);
+          args = sexp_list1(ctx, sexp_cdr(args));
           check_exception(ctx, sexp_apply(ctx, tmp, args));
         } else {
           fprintf(stderr, "couldn't find main binding: %s in %s\n", main_symbol, main_module ? main_module : argv[i]);

--- a/tests/run/lib/hello.sld
+++ b/tests/run/lib/hello.sld
@@ -3,9 +3,9 @@
   (begin
     (define (main args)
       (write-string "Hello, ")
-      (write-string (if (pair? (cdr args)) (cadr args) "world!"))
+      (write-string (if (pair? args) (car args) "world!"))
       (newline))
     (define (bye args)
       (write-string "Goodbye, ")
-      (write-string (if (pair? (cdr args)) (cadr args) "world!"))
+      (write-string (if (pair? args) (car args) "world!"))
       (newline))))


### PR DESCRIPTION
While the `(command-line)` in `(scheme process-context)` contains the command name (`argv[0]`), SRFI 22 specifies that the interpreter passes the command-line arguments except `argv[0]` to the script.

Fix #413.