### PR TITLE
Repair Emscripten building process

### DIFF
--- a/lib/srfi/144/math.stub
+++ b/lib/srfi/144/math.stub
@@ -39,14 +39,19 @@
   FP_SUBNORMAL)
 
 (c-declare
- "#ifndef FP_FAST_FMA
+ "#if defined(__EMSCRIPTEN__) || !defined(FP_FAST_FMA)
 #define FP_FAST_FMA 0
 #endif")
 
 (define-c-const boolean
   (fl-fast-+* FP_FAST_FMA))
 
-(define-c double (fl+* "fma") (double double double))
+(cond-expand
+  (emscripten
+    (c-declare "#define flmuladd(x, y, z) ((x) * (y) + (z))")
+    (define-c double (fl+* "flmuladd") (double double double)))
+  (else
+    (define-c double (fl+* "fma") (double double double))))
 
 ;; These aren't any faster than the builtin ops.  It might be
 ;; interesting to provide these as a way to get flonum support when


### PR DESCRIPTION
With this patch, compiling Chibi with Emscripten to a JavaScript binary works again by simply issuing

```shell
make js
```

The result will be in the `js` subfolder.  Note that you have to make a `dist-clean` afterwards if you want to set the stage for a compilation to the host machine.

As Emscripten does not provide the `fma` instruction, the patch includes a hack to the implementation of SRFI 144, which emulates `fma(x, y, z)` by `x * y + z`.  It is a hack because the rounding is not completely correct.

I tested the patch with the latest Emscripten version 1.37.16, which must be installed prior making `js`.

This should close #325.
