### PR TITLE
[RFC] Treat `scheme-r7rs` command name as in SRFI 22.

### DIFF
--- a/main.c
+++ b/main.c
@@ -304,6 +304,17 @@ sexp run_main (int argc, char **argv) {
   args = SEXP_NULL;
   env = NULL;
 
+  /* SRFI 22: invoke `main` procedure by default if the interpreter is invoked */
+  /* as `scheme-r7rs`. */
+  if (strncmp(basename(argv[0]), "scheme-r7rs", strlen("scheme-r7rs")) == 0) {
+    main_symbol = "main";
+    /* skip option parsing since we can't pass `--` before the name of script */
+    /* to avoid misinterpret the name as options when the interpreter is */
+    /* executed via `#!/usr/env/bin scheme-r7rs` shebang.  */
+    i = 1;
+    goto done_options;
+  }
+
   /* parse options */
   for (i=1; i < argc && argv[i][0] == '-'; i++) {
     switch ((c=argv[i][1])) {


### PR DESCRIPTION
I wrote a patch for #416 but I have no idea how we test the feature without making some duplicated code in `tests/run`. Would you give me some advice, or is it acceptable to make a clone of `command-line-tests.sh
`?