### PR TITLE
Win32: Fix win32 port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,11 @@ TEMPFILE := $(shell mktemp -t chibi.XXXXXX)
 
 ########################################################################
 
-CHIBI_COMPILED_LIBS = lib/chibi/filesystem$(SO) lib/chibi/process$(SO) \
-	lib/chibi/time$(SO) lib/chibi/system$(SO) lib/chibi/stty$(SO) \
-	lib/chibi/weak$(SO) lib/chibi/heap-stats$(SO) lib/chibi/disasm$(SO) \
-	lib/chibi/net$(SO) lib/chibi/ast$(SO) lib/chibi/emscripten$(SO)
+CHIBI_COMPILED_LIBS = lib/chibi/filesystem$(SO) lib/chibi/weak$(SO) \
+	lib/chibi/heap-stats$(SO) lib/chibi/disasm$(SO) lib/chibi/ast$(SO) \
+	lib/chibi/emscripten$(SO)
+CHIBI_POSIX_COMPILED_LIBS = lib/chibi/process$(SO) lib/chibi/time$(SO) \
+	lib/chibi/system$(SO) lib/chibi/stty$(SO) lib/chibi/net$(SO) 
 CHIBI_CRYPTO_COMPILED_LIBS = lib/chibi/crypto/crypto$(SO)
 CHIBI_IO_COMPILED_LIBS = lib/chibi/io/io$(SO)
 CHIBI_OPT_COMPILED_LIBS = lib/chibi/optimize/rest$(SO) \
@@ -36,9 +37,13 @@ EXTRA_COMPILED_LIBS ?=
 COMPILED_LIBS = $(CHIBI_COMPILED_LIBS) $(CHIBI_IO_COMPILED_LIBS) \
 	$(CHIBI_OPT_COMPILED_LIBS) $(CHIBI_CRYPTO_COMPILED_LIBS) \
 	$(EXTRA_COMPILED_LIBS) \
-	lib/srfi/18/threads$(SO) lib/srfi/27/rand$(SO) lib/srfi/151/bit$(SO) \
+	lib/srfi/27/rand$(SO) lib/srfi/151/bit$(SO) \
 	lib/srfi/39/param$(SO) lib/srfi/69/hash$(SO) lib/srfi/95/qsort$(SO) \
 	lib/srfi/98/env$(SO) lib/srfi/144/math$(SO) lib/scheme/time$(SO)
+
+ifndef EXCLUDE_POSIX_LIBS
+COMPILED_LIBS += $(CHIBI_POSIX_COMPILED_LIBS) lib/srfi/18/threads$(SO) 
+endif
 
 BASE_INCLUDES = include/chibi/sexp.h include/chibi/features.h include/chibi/install.h include/chibi/bignum.h
 INCLUDES = $(BASE_INCLUDES) include/chibi/eval.h include/chibi/gc_heap.h

--- a/Makefile.detect
+++ b/Makefile.detect
@@ -45,6 +45,7 @@ endif
 endif
 endif
 endif
+endif
 
 ########################################################################
 # Set default variables for the platform.
@@ -73,24 +74,22 @@ else
 ifeq ($(PLATFORM),windows)
 SO  = .dll
 EXE = .exe
-CC = gcc
+CC ?= gcc
 CLIBFLAGS =
 CLINKFLAGS = -shared
 CPPFLAGS += -DSEXP_USE_STRING_STREAMS=0 -DSEXP_USE_GREEN_THREADS=0 -DSEXP_USE_GC_FILE_DESCRIPTORS=0 -DBUILDING_DLL
 LIBCHIBI_FLAGS = -Wl,--out-implib,libchibi-scheme$(SO).a
-STATICFLAGS = -DSEXP_USE_DL=0
+STATICFLAGS =
 LIBDL = -lws2_32
 else
-ifeq ($(PLATFORM),mingw)
+ifeq ($(PLATFORM),msys)
 SO  = .dll
 EXE = .exe
 CC = gcc
 CLIBFLAGS =
 CLINKFLAGS = -shared
-CPPFLAGS += -DSEXP_USE_STRING_STREAMS=0 -DSEXP_USE_GREEN_THREADS=0 -DBUILDING_DLL
+CPPFLAGS += -DSEXP_USE_STRING_STREAMS=0
 LIBCHIBI_FLAGS = -Wl,--out-implib,libchibi-scheme$(SO).a
-STATICFLAGS = -DSEXP_USE_DL=0
-LIBDL = -lws2_32
 else
 ifeq ($(PLATFORM),cygwin)
 SO  = .dll
@@ -110,7 +109,6 @@ LIBCHIBI_FLAGS = -Wl,-soname,libchibi-scheme$(SO).$(SOVERSION_MAJOR)
 ifeq ($(PLATFORM),BSD)
 LIBDL=
 RLDFLAGS=-Wl,-R$(DESTDIR)$(LIBDIR)
-endif
 endif
 endif
 endif

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+    matrix:
+        - ARCH: x64
+        - ARCH: x86
+        - ARCH: msys
+
+build_script:
+    - if %ARCH%.==x64. set PATH=c:\msys64\usr\bin;c:\msys64\mingw64\bin;%PATH%
+    - if %ARCH%.==x86. set PATH=c:\msys64\usr\bin;c:\msys64\mingw32\bin;%PATH%
+    - if %ARCH%.==msys. set PATH=c:\msys64\usr\bin;%PATH%
+    - if %ARCH%.==x64. set CC=c:/msys64/mingw64/bin/gcc
+    - if %ARCH%.==x86. set CC=c:/msys64/mingw32/bin/gcc
+    - if %ARCH%.==msys. set CC=gcc
+    - if %ARCH%.==x64. set EXARG=EXCLUDE_POSIX_LIBS=1
+    - if %ARCH%.==x86. set EXARG=EXCLUDE_POSIX_LIBS=1
+    - if %ARCH%.==msys. set EXARG=PLATFORM=msys
+    - make CC=%CC% %EXARG% 
+    - make CC=%CC% %EXARG% test
+

--- a/bignum.c
+++ b/bignum.c
@@ -531,8 +531,8 @@ sexp sexp_bignum_quot_rem (sexp ctx, sexp *rem, sexp a, sexp b) {
            << (sizeof(sexp_uint_t)*8))
           + sexp_bignum_data(b1)[blen-2]);
     if (alen > 2 && blen > 2 &&
-        sexp_bignum_data(a1)[alen-1] < (1uL<<(sizeof(sexp_uint_t)*4)) &&
-        sexp_bignum_data(b1)[blen-1] < (1uL<<(sizeof(sexp_uint_t)*4))) {
+        sexp_bignum_data(a1)[alen-1] < ((sexp_luint_t)1<<(sizeof(sexp_uint_t)*4)) &&
+        sexp_bignum_data(b1)[blen-1] < ((sexp_luint_t)1<<(sizeof(sexp_uint_t)*4))) {
       dn = (dn << (sizeof(sexp_uint_t)*4))
         + (sexp_bignum_data(a1)[alen-3] >> (sizeof(sexp_uint_t)*4));
       dd = (dd << (sizeof(sexp_uint_t)*4))
@@ -544,8 +544,8 @@ sexp sexp_bignum_quot_rem (sexp ctx, sexp *rem, sexp a, sexp b) {
              << (sizeof(sexp_uint_t)*8))
             + sexp_bignum_data(a1)[alen-2]);
       dd = sexp_bignum_data(b1)[blen-1];
-      if (sexp_bignum_data(a1)[alen-1] < (1uL<<(sizeof(sexp_uint_t)*4)) &&
-          sexp_bignum_data(b1)[blen-1] < (1uL<<(sizeof(sexp_uint_t)*4))) {
+      if (sexp_bignum_data(a1)[alen-1] < ((sexp_luint_t)1<<(sizeof(sexp_uint_t)*4)) &&
+          sexp_bignum_data(b1)[blen-1] < ((sexp_luint_t)1<<(sizeof(sexp_uint_t)*4))) {
         dn = (dn << (sizeof(sexp_uint_t)*4))
           + (sexp_bignum_data(a1)[alen-3] >> (sizeof(sexp_uint_t)*4));
         dd = (dd << (sizeof(sexp_uint_t)*4))

--- a/eval.c
+++ b/eval.c
@@ -1324,7 +1324,7 @@ static struct sexp_library_entry_t *sexp_find_static_library(const char *file)
 #endif
 
 #if SEXP_USE_DL
-#ifdef __MINGW32__
+#ifdef _WIN32
 #include <windows.h>
 static sexp sexp_load_dl (sexp ctx, sexp file, sexp env) {
   sexp res;

--- a/gc.c
+++ b/gc.c
@@ -90,7 +90,7 @@ void sexp_release_object(sexp ctx, sexp x) {
     }
 }
 
-sexp_uint_t sexp_allocated_bytes (sexp ctx, sexp x) {
+SEXP_API sexp_uint_t sexp_allocated_bytes (sexp ctx, sexp x) {
   sexp_uint_t res;
   sexp t;
   if (!sexp_pointerp(x) || (sexp_pointer_tag(x) >= sexp_context_num_types(ctx)))

--- a/gc_heap.c
+++ b/gc_heap.c
@@ -480,6 +480,13 @@ done:
   return res;
 }
 
+#ifdef _WIN32
+static void* load_image_fn(sexp ctx, sexp dl, sexp name) {
+  snprintf(gc_heap_err_str, ERR_STR_SIZE,
+           "load_image_fn: Needed to be ported to Win32");
+  return NULL;
+}
+#else
 static void* load_image_fn(sexp ctx, sexp dl, sexp name) {
   sexp ls;
   void *fn = NULL;
@@ -525,6 +532,7 @@ static void* load_image_fn(sexp ctx, sexp dl, sexp name) {
   }
   return fn;
 }
+#endif
 
 static sexp load_image_callback_p2 (sexp ctx, sexp dstp, void *user) {
   sexp res = NULL;

--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -342,7 +342,7 @@
 #endif
 
 #ifndef SEXP_USE_DL
-#if defined(PLAN9) || defined(_WIN32)
+#if defined(PLAN9)
 #define SEXP_USE_DL 0
 #else
 #define SEXP_USE_DL ! SEXP_USE_NO_FEATURES
@@ -770,18 +770,21 @@
 #define isinf(x) (isInf(x,1) || isInf(x,-1))
 #define isnan(x) isNaN(x)
 #elif defined(_WIN32)
-#define _CRT_SECURE_NO_WARNINGS 1
-#define _CRT_NONSTDC_NO_DEPRECATE 1
-#pragma warning(disable:4146) /* unary minus operator to unsigned type */
-#ifdef __MINGW32__
-#include <shlwapi.h>
+#define SHUT_RD 0 /* SD_RECEIVE */
+#define SHUT_WR 1 /* SD_SEND */
+#define SHUT_RDWR 2 /* SD_BOTH */
+#if !defined(__MINGW32__) && !defined(__MINGW64__)
 #define strcasecmp lstrcmpi
 #define strncasecmp(s1, s2, n) lstrcmpi(s1, s2)
+#endif
+#include <shlwapi.h>
 #define strcasestr StrStrI
-#define SHUT_RD 0
-#define SHUT_WR 1
-#define SHUT_RDWR 2
-#else
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS 1
+#define _CRT_NONSTDC_NO_DEPRECATE 1
+#define _USE_MATH_DEFINES /* For M_LN10 */
+#pragma warning(disable:4146) /* unary minus operator to unsigned type */
+#if _MSC_VER < 1900
 #define snprintf(buf, len, fmt, val) sprintf(buf, fmt, val)
 #define strcasecmp lstrcmpi
 #define strncasecmp(s1, s2, n) lstrcmpi(s1, s2)
@@ -789,6 +792,9 @@
 #define trunc(x) floor((x)+0.5*(((x)<0)?1:0))
 #define isnan(x) (x!=x)
 #define isinf(x) (x > DBL_MAX || x < -DBL_MAX)
+#endif
+#elif !defined(__MINGW32__)
+#error Unknown Win32 compiler!
 #endif
 #endif
 
@@ -806,7 +812,7 @@
 #define sexp_nan (0.0/0.0)
 #endif
 
-#ifdef __MINGW32__
+#ifdef _WIN32
 #ifdef BUILDING_DLL
 #define SEXP_API    __declspec(dllexport)
 #else

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -17,8 +17,9 @@ extern "C" {
 #include "chibi/features.h"
 #include "chibi/install.h"
 
-#if defined(_WIN32) || defined(__MINGW32__)
+#ifdef _WIN32
 #include <windows.h>
+#include <errno.h>
 #define sexp_isalpha(x) ((isalpha)((int)(x)))
 #define sexp_isxdigit(x) ((isxdigit)((int)(x)))
 #define sexp_isdigit(x) ((isdigit)((int)(x)))
@@ -197,15 +198,20 @@ enum sexp_types {
 #define SEXP_STRING_CURSOR SEXP_FIXNUM
 #endif
 
-/* procedure flags */
-#define SEXP_PROC_NONE 0uL
-#define SEXP_PROC_VARIADIC 1uL
-#define SEXP_PROC_UNUSED_REST 2uL
-
 #ifdef _WIN32
+#if defined(_MSC_VER) && SEXP_64_BIT
+/* On SEXP_64_BIT, 128bits arithmetic is mandatory */
+#error Unsupported configuration
+#endif
+#if SEXP_64_BIT
+typedef unsigned int sexp_tag_t;
+typedef unsigned long long sexp_uint_t;
+typedef long long sexp_sint_t;
+#else
 typedef unsigned short sexp_tag_t;
-typedef SIZE_T sexp_uint_t;
-typedef SSIZE_T sexp_sint_t;
+typedef unsigned int sexp_uint_t;
+typedef int sexp_sint_t;
+#endif
 #define sexp_heap_align(n) sexp_align(n, 5)
 #define sexp_heap_chunks(n) (sexp_heap_align(n)>>5)
 #elif SEXP_64_BIT
@@ -227,6 +233,12 @@ typedef int sexp_sint_t;
 #define sexp_heap_align(n) sexp_align(n, 4)
 #define sexp_heap_chunks(n) (sexp_heap_align(n)>>4)
 #endif
+
+/* procedure flags */
+#define SEXP_PROC_NONE ((sexp_uint_t)0)
+#define SEXP_PROC_VARIADIC ((sexp_uint_t)1)
+#define SEXP_PROC_UNUSED_REST ((sexp_uint_t)2)
+
 
 #ifdef SEXP_USE_INTTYPES
 # include <inttypes.h>
@@ -309,6 +321,7 @@ typedef sexp (*sexp_proc5) (sexp, sexp, sexp_sint_t, sexp, sexp, sexp, sexp);
 typedef sexp (*sexp_proc6) (sexp, sexp, sexp_sint_t, sexp, sexp, sexp, sexp, sexp);
 typedef sexp (*sexp_proc7) (sexp, sexp, sexp_sint_t, sexp, sexp, sexp, sexp, sexp, sexp);
 typedef sexp (*sexp_init_proc)(sexp, sexp, sexp_sint_t, sexp, const char*, const sexp_abi_identifier_t);
+SEXP_API sexp sexp_init_library(sexp, sexp, sexp_sint_t, sexp, const char*, const sexp_abi_identifier_t);
 
 typedef struct sexp_free_list_t *sexp_free_list;
 struct sexp_free_list_t {
@@ -720,7 +733,7 @@ SEXP_API sexp sexp_make_flonum(sexp ctx, float f);
 #define sexp_flonump(x)      (sexp_check_tag(x, SEXP_FLONUM))
 #define sexp_flonum_value(f) ((f)->value.flonum)
 #define sexp_flonum_bits(f) ((f)->value.flonum_bits)
-sexp sexp_make_flonum(sexp ctx, double f);
+SEXP_API sexp sexp_make_flonum(sexp ctx, double f);
 #endif
 
 #define sexp_typep(x)       (sexp_check_tag(x, SEXP_TYPE))
@@ -806,8 +819,8 @@ SEXP_API int sexp_idp(sexp x);
 #define sexp_make_fixnum(n)    ((sexp) ((((sexp_sint_t)(n))<<SEXP_FIXNUM_BITS) + SEXP_FIXNUM_TAG))
 #define sexp_unbox_fixnum(n)   (((sexp_sint_t)(n))>>SEXP_FIXNUM_BITS)
 #else
-#define sexp_make_fixnum(n)    ((sexp) ((((sexp_sint_t)(n))*(sexp_sint_t)(1uL<<SEXP_FIXNUM_BITS)) | SEXP_FIXNUM_TAG))
-#define sexp_unbox_fixnum(n)   (((sexp_sint_t)((sexp_uint_t)(n) & ~SEXP_FIXNUM_TAG))/(sexp_sint_t)(1uL<<SEXP_FIXNUM_BITS))
+#define sexp_make_fixnum(n)    ((sexp) ((((sexp_sint_t)(n))*(sexp_sint_t)((sexp_sint_t)1<<SEXP_FIXNUM_BITS)) | SEXP_FIXNUM_TAG))
+#define sexp_unbox_fixnum(n)   (((sexp_sint_t)((sexp_uint_t)(n) & ~SEXP_FIXNUM_TAG))/(sexp_sint_t)((sexp_sint_t)1<<SEXP_FIXNUM_BITS))
 #endif
 
 #define SEXP_NEG_ONE sexp_make_fixnum(-1)

--- a/sexp.c
+++ b/sexp.c
@@ -168,10 +168,17 @@ sexp sexp_finalize_port (sexp ctx, sexp self, sexp_sint_t n, sexp port) {
 }
 
 #if SEXP_USE_DL
+#ifdef _WIN32
+sexp sexp_finalize_dl (sexp ctx, sexp self, sexp_sint_t n, sexp dl) {
+  FreeLibrary(sexp_dl_handle(dl));
+  return SEXP_VOID;
+}
+#else
 sexp sexp_finalize_dl (sexp ctx, sexp self, sexp_sint_t n, sexp dl) {
   dlclose(sexp_dl_handle(dl));
   return SEXP_VOID;
 }
+#endif
 #endif
 
 static struct sexp_type_struct _sexp_type_specs[] = {
@@ -386,7 +393,7 @@ static const char* sexp_initial_features[] = {
 #if SEXP_BSD
   "bsd",
 #endif
-#if defined(_WIN32) || defined(__MINGW32__)
+#if defined(_WIN32)
   "windows",
 #endif
 #if SEXP_USE_DL
@@ -1224,7 +1231,7 @@ sexp sexp_string_concatenate_op (sexp ctx, sexp self, sexp_sint_t n, sexp str_ls
 }
 
 #define FNV_PRIME 16777619
-#define FNV_OFFSET_BASIS 2166136261uL
+#define FNV_OFFSET_BASIS ((sexp_sint_t)2166136261)
 
 #if SEXP_USE_HASH_SYMS
 
@@ -1423,7 +1430,7 @@ int sexp_buffered_write_string (sexp ctx, const char *str, sexp p) {
 }
 
 int sexp_buffered_flush (sexp ctx, sexp p, int forcep) {
-  long res = 0, off;
+  sexp_sint_t res = 0, off;
   sexp_gc_var1(tmp);
   if (!sexp_oportp(p) || (!forcep && !sexp_port_openp(p)))
     return -1;
@@ -1860,10 +1867,10 @@ sexp sexp_apply_writer(sexp ctx, sexp writer, sexp obj, sexp out) {
 
 sexp sexp_write_one (sexp ctx, sexp obj, sexp out) {
 #if SEXP_USE_HUFF_SYMS
-  unsigned long res;
+  sexp_uint_t res;
 #endif
-  unsigned long len, c;
-  long i=0;
+  sexp_uint_t len, c;
+  sexp_sint_t i=0;
 #if SEXP_USE_FLONUMS
   double f, ftmp;
 #endif
@@ -1895,7 +1902,7 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out) {
       } else {
         sexp_write_string(ctx, "#(", out);
         sexp_write_one(ctx, elts[0], out);
-        for (i=1; i<(long)len; i++) {
+        for (i=1; i<(sexp_sint_t)len; i++) {
           sexp_write_char(ctx, ' ', out);
           sexp_write_one(ctx, elts[i], out);
         }
@@ -2045,7 +2052,7 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out) {
       sexp_write_string(ctx, "#u8(", out);
       str = sexp_bytes_data(obj);
       len = sexp_bytes_length(obj);
-      for (i=0; i<(long)len; i++) {
+      for (i=0; i<(sexp_sint_t)len; i++) {
         if (i!=0) sexp_write_char(ctx, ' ', out);
         sexp_write(ctx, sexp_make_fixnum(((unsigned char*)str)[i]), out);
       }


### PR DESCRIPTION
Try to fix win32 port. Now it runs both on Win32/Win64.

Win64 port depends on 128bits arithmetic thus it does not run on MSVC.

- `sexp_make_integer` and `sexp_make_unsigned_integer`: I guess lsint/luint types are not intended to be used outside of bignum implementation. Use sint/uint types to be compatible with non-bignum portions.
- Various LLP64 support.