### PR TITLE
main: Silence warning with !SEXP_USE_GREEN_THREADS

### DIFF
--- a/main.c
+++ b/main.c
@@ -94,7 +94,7 @@ static void sexp_make_unblocking (sexp ctx, sexp port) {
       sexp_port_flags(port) |= O_NONBLOCK;
 }
 #else
-#define sexp_make_unblocking(ctx, port) 0
+#define sexp_make_unblocking(ctx, port) (void)0
 #endif
 
 static sexp sexp_meta_env (sexp ctx) {


### PR DESCRIPTION
Trivial. `sexp_make_unblocking` has no return value on `SEXP_USE_GREEN_THREADS`. Match it on `!SEXP_USE_GREEN_THREADS` compile.