### PR TITLE
ast.c: #include <stdlib.h> for setenv()

### DIFF
--- a/lib/chibi/ast.c
+++ b/lib/chibi/ast.c
@@ -5,6 +5,7 @@
 #include <chibi/eval.h>
 
 #ifndef PLAN9
+#include <stdlib.h>
 #include <errno.h>
 #endif
 


### PR DESCRIPTION
ast.c has `setenv`() references so we need to include `<stdlib.h>`

Alternatively, we can move this block entirely because `<chibi/eval.h>` → `<chibi/sexp.h>` has the same block for `<errno.h>` but it seems including it on `ast.c` would be the better fit.