### PR TITLE
Several changes of syntax-rules in init-7.scm

### DIFF
--- a/tests/r7rs-tests.scm
+++ b/tests/r7rs-tests.scm
@@ -565,6 +565,35 @@
                    (n z))))))
   (test 'bound-identifier=? (m k)))
 
+;; literal has priority to ellipsis (R7RS 4.3.2)
+(let ()
+  (define-syntax elli-lit-1
+    (syntax-rules ... (...)
+      ((_ x)
+       '(x ...))))
+  (test '(100 ...) (elli-lit-1 100)))
+
+;; bad ellipsis
+#|
+(test 'error
+      (guard (exn (else 'error))
+        (eval
+         '(define-syntax bad-elli-1
+            (syntax-rules ()
+              ((_ ... x)
+               '(... x))))
+         (interaction-environment))))
+
+(test 'error
+      (guard (exn (else 'error))
+        (eval
+         '(define-syntax bad-elli-2
+            (syntax-rules ()
+              ((_ (... x))
+               '(... x))))
+         (interaction-environment))))
+|#
+
 (test-end)
 
 (test-begin "5 Program structure")


### PR DESCRIPTION
Hello.
I tried to use srfi-149 in Gauche and found some issues.
I changed 'syntax-rules' in init-7.scm as follows for feedback.

1. Add 'bad ellipsis' error check.
   Sorry, test case 'bad ellipsis' is now commented out
   because I coudn't handle error properly.

2. Literal has priority to ellipsis (R7RS 4.3.2).
   ( https://srfi-email.schemers.org/srfi-148/msg/6115633 )
   I added 'ellipsis-mark?' procedure.

3. Remove syntax-rules/aux.
   If 'ellipsis-specified?' is true, I use 'eq?' in 'ellipsis-mark?' ( same as literals ).
   If 'ellipsis-specified?' is false, I use 'compare' in 'ellipsis-mark?' (same as underscore ).
   By these changes, I considered that the binding of ellipsis and syntax-rules/aux could be removed.
   If this is wrong consideration, please tell me ...
