### PR TITLE
Misc. fixes for Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # Shared objects (inc. Windows DLLs)
 *.dll
+*.dll.*
 *.so
 *.so.*
 *.dylib
@@ -48,6 +49,7 @@ lib/chibi/process.c
 lib/chibi/stty.c
 lib/chibi/system.c
 lib/chibi/time.c
+lib/chibi/win32/process-win32.c
 lib/srfi/144/math.c
 *.tgz
 *.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ set(testexcludes
     chibi/doc-test # Depends (chibi time)
     chibi/system-test
     chibi/tar-test # Depends (chibi system)
+    chibi/process-test # Not applicable
     )
 
 set(testlibs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,8 +250,6 @@ foreach(e ${chibi-scheme-tests})
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
-message(STATUS "Detecting library tests")
-
 file(GLOB_RECURSE srfi_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/lib/srfi/*/test.sld)
 
@@ -287,6 +285,5 @@ foreach(e ${testlibs})
         COMMAND chibi-scheme -e "(import (${form}))"
         -e "(run-tests)"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    message(STATUS "Test ${testname}")
 endforeach()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ environment:
         - ARCH: x86
           TOOLCHAIN: MinGW
           BUILDSYSTEM: CMAKE
+        - ARCH: x64
+          TOOLCHAIN: MinGW
+          BUILDSYSTEM: CMAKE
         - ARCH: x86
           TOOLCHAIN: MSVC
           BUILDSYSTEM: CMAKE


### PR DESCRIPTION
- Added `.gitignore` entries for Win32 specific output
- Forgot to add Win64 MinGW CMake case for AppVeyor
- Exclude `(chibi process)` test for CMake builds
- Exclude `readlink`, `file-link-status`, `stat-blocks` and `stat-blksize` from `(chibi filesystem)` in `windows` to suppress warnings
