### PR TITLE
Raise type error if remainder called with infinity.

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -1667,8 +1667,11 @@ sexp sexp_remainder (sexp ctx, sexp a, sexp b) {
 #if SEXP_USE_RATIOS
   case SEXP_NUM_FLO_RAT:
 #endif
-    if (sexp_flonum_value(a) != trunc(sexp_flonum_value(a))) {
+    if (isinf(sexp_flonum_value(a)) ||
+        sexp_flonum_value(a) != trunc(sexp_flonum_value(a))) {
       r = sexp_type_exception(ctx, NULL, SEXP_FIXNUM, a);
+    } else if (bt == SEXP_NUM_FLO && isinf(sexp_flonum_value(b))) {
+      r = sexp_type_exception(ctx, NULL, SEXP_FIXNUM, b);
     } else {
       tmp = sexp_bignum_normalize(sexp_double_to_bignum(ctx, sexp_flonum_value(a)));
       tmp = sexp_remainder(ctx, tmp, b);
@@ -1691,7 +1694,8 @@ sexp sexp_remainder (sexp ctx, sexp a, sexp b) {
 #if SEXP_USE_RATIOS
   case SEXP_NUM_RAT_FLO:
 #endif
-    if (sexp_flonum_value(b) != trunc(sexp_flonum_value(b))) {
+    if (isinf(sexp_flonum_value(b)) ||
+        sexp_flonum_value(b) != trunc(sexp_flonum_value(b))) {
       r = sexp_type_exception(ctx, NULL, SEXP_FIXNUM, b);
     } else {
       tmp = sexp_bignum_normalize(sexp_double_to_bignum(ctx, sexp_flonum_value(b)));


### PR DESCRIPTION
To prevent an infinite loop, raise a type error if the `remainder` procedure is called with `+inf.0` or `-inf.0` as either argument.

Before this change, `(remainder +inf.0 2)` and `(remainder 2 +inf.0)` would never return. This also affects any procedure that calls `remainder`, such as `odd?`, `even?`, `modulo`, `gcd`, and `lcm`. For example, `(odd? +inf.0)` would never return, which is how I discovered this bug.

Here is a simple test suite, which I did not include in the commit because I'm not sure where to put it:

```scheme
(import (scheme base) (chibi test))

(test-begin "remainder infinity")

(test-error (remainder +inf.0 2))
(test-error (remainder -inf.0 2))
(test-error (remainder +inf.0 2.0))
(test-error (remainder -inf.0 2.0))
(test-error (remainder +inf.0 2/1))
(test-error (remainder -inf.0 2/1))

(test-error (remainder 2 +inf.0))
(test-error (remainder 2 -inf.0))
(test-error (remainder 2.0 +inf.0))
(test-error (remainder 2.0 -inf.0))
(test-error (remainder 2/1 +inf.0))
(test-error (remainder 2/1 -inf.0))

(test-end "remainder infinity")
```