### PR TITLE
Check for valid "rest" parameters in parameter lists

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -806,6 +806,12 @@ static sexp analyze_lambda (sexp ctx, sexp x, int depth) {
       sexp_return(res, sexp_compile_error(ctx, "non-symbol parameter", x));
     else if (sexp_truep(sexp_memq(ctx, sexp_car(ls), sexp_cdr(ls))))
       sexp_return(res, sexp_compile_error(ctx, "duplicate parameter", x));
+  if (! sexp_nullp(ls)) {
+    if (! sexp_idp(ls))
+      sexp_return(res, sexp_compile_error(ctx, "non-symbol parameter", x));
+    else if (sexp_truep(sexp_memq(ctx, ls, sexp_cadr(x))))
+      sexp_return(res, sexp_compile_error(ctx, "duplicate parameter", x));
+  }
   /* build lambda and analyze body */
   res = sexp_make_lambda(ctx, tmp=sexp_copy_list(ctx, sexp_cadr(x)));
   if (sexp_exceptionp(res)) sexp_return(res, res);


### PR DESCRIPTION
Checks for invalid parameter names and duplicate parameters were being performed on parameter lists, but these checks were not considering any rest parameters.  So the behavior before this is that 

`(lambda (x x) x)` gives an error
`(lambda (x 0) x)` gives an error
`(lambda (x #t) x)` gives an error

but

`((lambda (x . x) x) 'foo 'bar)`  yields `foo`
`((lambda (x . 0) x) 'foo 'bar)` yields `foo`
`((lambda (x . #t) x) 'foo 'bar)` yields `foo`

and

`((lambda 0 'foo))` yields `foo`
`((lambda #t 'foo))` yields `foo`

And there are plenty of other examples.  Now these latter cases all produce errors.