### PR TITLE
test: Do not create file under /tmp in show-test

### DIFF
--- a/lib/chibi/show-test.sld
+++ b/lib/chibi/show-test.sld
@@ -730,7 +730,7 @@ def | 6
 
       ;; from-file
       ;; for reference, filesystem-test relies on creating files under /tmp
-      (let* ((tmp-file "/tmp/chibi-show-test-0123456789")
+      (let* ((tmp-file "chibi-show-test-0123456789")
              (content-string "first line\nsecond line\nthird line"))
         (with-output-to-file tmp-file (lambda () (write-string content-string)))
         (test (string-append content-string "\n")


### PR DESCRIPTION
Do not create test file under /tmp as it might break
concurrent builds. Creating file on the current directory should
suffice.

... and consider Windows -- it typically does not have `/tmp` (some have `c:\tmp` and it would work as `/tmp` though). 

filesystem-test intentionally left as-is because it is for POSIX.

Using `tmpfile()` API can be alternative except it returns `FILE*`.