### PR TITLE
(expt bignum -k) was equal to (expt bignum k)

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -610,14 +610,21 @@ sexp sexp_bignum_remainder (sexp ctx, sexp a, sexp b) {
 }
 
 sexp sexp_bignum_expt (sexp ctx, sexp a, sexp b) {
-  sexp_sint_t e = sexp_unbox_fx_abs(b);
+  sexp_sint_t e = sexp_unbox_fixnum(b);
+  sexp_sint_t abs_e;
+  if (e < 0)
+    abs_e = -e;
+  else
+    abs_e = e;
   sexp_gc_var2(res, acc);
   sexp_gc_preserve2(ctx, res, acc);
   res = sexp_fixnum_to_bignum(ctx, SEXP_ONE);
   acc = sexp_copy_bignum(ctx, NULL, a, 0);
-  for (; e; e>>=1, acc=sexp_bignum_mul(ctx, NULL, acc, acc))
-    if (e & 1)
+  for (; abs_e; abs_e>>=1, acc=sexp_bignum_mul(ctx, NULL, acc, acc))
+    if (abs_e & 1)
       res = sexp_bignum_mul(ctx, NULL, res, acc);
+  if (e < 0)
+    res = sexp_div(ctx, sexp_fixnum_to_bignum(ctx, SEXP_ONE), res);
   sexp_gc_release2(ctx);
   return sexp_bignum_normalize(res);
 }

--- a/lib/chibi/numeric-test.sld
+++ b/lib/chibi/numeric-test.sld
@@ -16,6 +16,10 @@
     (define (run-tests)
       (test-begin "numbers")
 
+      (test 3 (expt 3 1))
+      ;(test 1/3 (expt 3 -1))
+      (test 1/300000000000000000000 (expt 300000000000000000000 -1))
+
       (test '(536870912 536870913 536870911 -536870912 -536870911 -536870913)
           (integer-neighborhoods (expt 2 29)))
 


### PR DESCRIPTION
So here's a fix.
By the way there's an issue too with fixnums, (expt 3 -1) is not exact and I guess it should be.
Cheers,
Bertrand