### PR TITLE
Expt fix

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1706,6 +1706,11 @@ sexp sexp_expt_op (sexp ctx, sexp self, sexp_sint_t n, sexp x, sexp e) {
       res = sexp_make_flonum(ctx, pow(10.0, 1e100));   /* +inf.0 */
   } else if (sexp_bignump(x)) {
     res = sexp_bignum_expt(ctx, x, e);
+  } else if (sexp_fixnump(x)) {
+      sexp_gc_preserve1(ctx, tmp);
+      tmp = sexp_fixnum_to_bignum(ctx, x);
+      res = sexp_bignum_expt(ctx, tmp, e);
+      sexp_gc_release1(ctx);
   } else {
 #endif
   if (sexp_fixnump(x))

--- a/lib/chibi/numeric-test.sld
+++ b/lib/chibi/numeric-test.sld
@@ -16,8 +16,10 @@
     (define (run-tests)
       (test-begin "numbers")
 
+      (test 0 (expt 0 1))
+      (test 1 (expt 3 0))
       (test 3 (expt 3 1))
-      ;(test 1/3 (expt 3 -1))
+      (test 1/3 (expt 3 -1))
       (test 1/300000000000000000000 (expt 300000000000000000000 -1))
 
       (test '(536870912 536870913 536870911 -536870912 -536870911 -536870913)


### PR DESCRIPTION
(expt 3 -1) yielded a flonum instead of a fraction, so here's this one.
Didn't check what it does when bignum support is not there but it probably doesn't work according to what I can guess :) 