### PR TITLE
Fix syntax-rules on ellipsis escape templates

### DIFF
--- a/tests/r7rs-tests.scm
+++ b/tests/r7rs-tests.scm
@@ -447,6 +447,20 @@
 (be-like-begin3 sequence3)
 (test 5 (sequence3 2 3 4 5))
 
+;; ellipsis escape
+(define-syntax elli-esc-1
+  (syntax-rules ()
+    ((_)
+     '(... ...))
+    ((_ x)
+     '(... (x ...)))
+    ((_ x y)
+     '(... (... x y)))))
+
+(test '... (elli-esc-1))
+(test '(100 ...) (elli-esc-1 100))
+(test '(... 100 200) (elli-esc-1 100 200))
+
 ;; Syntax pattern with ellipsis in middle of proper list.
 (define-syntax part-2
   (syntax-rules ()


### PR DESCRIPTION
Hello.
I found that ellipsis escape templates do not expand pattern variables.

```
(define-syntax elli-esc-1
  (syntax-rules ()
    ((_ x)
     (... 'x))))
(elli-esc-1 100) ; ==> x (should be 100)
```

I tried to fix it.
