### PR TITLE
Avoid undefined C macro behavior

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Thanks to the following people for patches and bug reports:
   * Jeronimo Pellegrini
   * John Cowan
   * John Samsa
+  * Kris Katterjohn
   * Lars J Aas
   * Lorenzo Campedelli
   * Marc Nieper-Wißkirchen

--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -304,7 +304,11 @@
 /* for bignum support, need a double long to store long*long */
 /* gcc supports uint128_t, otherwise we need a custom struct */
 #ifndef SEXP_USE_CUSTOM_LONG_LONGS
-#define SEXP_USE_CUSTOM_LONG_LONGS (SEXP_64_BIT && !defined(__GNUC__))
+#if SEXP_64_BIT && !defined(__GNUC__)
+#define SEXP_USE_CUSTOM_LONG_LONGS 1
+#else
+#define SEXP_USE_CUSTOM_LONG_LONGS 0
+#endif
 #endif
 
 #ifndef SEXP_USE_NO_FEATURES


### PR DESCRIPTION
Hello again!

A C macro expanding to a `defined` has undefined behavior and the clang compiler was issuing warnings.  This problem was only in one place, and this commit fixes the issue by rewriting it a little to avoid the undefined behavior.