### PR TITLE
add history support as $0...9

### DIFF
--- a/lib/chibi/repl.scm
+++ b/lib/chibi/repl.scm
@@ -305,6 +305,38 @@
            (else
             (display "... none found.\n" out))))))))))
 
+(define undefined-value (if #f #f))
+
+(define $0 undefined-value)
+(define $1 undefined-value)
+(define $2 undefined-value)
+(define $3 undefined-value)
+(define $4 undefined-value)
+(define $5 undefined-value)
+(define $6 undefined-value)
+(define $7 undefined-value)
+(define $8 undefined-value)
+(define $9 undefined-value)
+
+(define (push-history-value! value)
+  (set! $9 $8)
+  (set! $8 $7)
+  (set! $7 $6)
+  (set! $6 $5)
+  (set! $5 $4)
+  (set! $4 $3)
+  (set! $3 $2)
+  (set! $2 $1)
+  (set! $1 $0)
+  (set! $0 value))
+
+(define (push-history-value-maybe! value)
+  (cond ((eq? value undefined-value) undefined-value)
+        ((not (list? value)) (push-history-value! value))
+        ((= (length value) 0) undefined-value)
+        ((= (length value) 1) (push-history-value! (car value)))
+        (else (push-history-value! value))))
+
 (define (repl/eval rp expr-list)
   (let ((out (repl-out rp)))
     (protect (exn (else (print-exception exn out)))
@@ -330,6 +362,7 @@
                          (cond
                           ((not (or (null? res-list)
                                     (equal? res-list (list (if #f #f)))))
+                           (push-history-value-maybe! res-list)
                            (write/ss (car res-list) out)
                            (for-each
                             (lambda (res)
@@ -466,4 +499,5 @@
             (lambda (out) (write (history->list (repl-history rp)) out)))))))
 
 (define (main args)
+  (import (only (chibi repl) $0 $1 $2 $3 $4 $5 $6 $7 $8 $9))
   (repl))

--- a/lib/chibi/repl.scm
+++ b/lib/chibi/repl.scm
@@ -165,6 +165,13 @@
 ;;> \item{\scheme|{\exit}| - exit the REPL}
 ;;> ]
 
+;;> The results of the last ten successful evaluations are available
+;;> via a history facility. \var{$0} holds the most recent result
+;;> while \var{$9} holds the tenth-most recent result. Evaluations
+;;> yielding single values are stored as single values while evaluations
+;;> that yield multiple values are stored as lists of values. 
+
+
 (define-record-type Repl
   (make-repl
    in out escape module env meta-env make-prompt history-file history raw?)

--- a/lib/chibi/repl.sld
+++ b/lib/chibi/repl.sld
@@ -1,6 +1,6 @@
 
 (define-library (chibi repl)
-  (export repl)
+  (export repl $0 $1 $2 $3 $4 $5 $6 $7 $8 $9)
   (import (chibi) (only (meta) load-module)
           (chibi ast) (chibi modules) (chibi doc)
           (chibi string) (chibi io) (chibi optional)


### PR DESCRIPTION
This PR pushes values produced at the REPL onto a history stack, implemented as ten values bound as $0...$9. Expressions evaluating to a single value are pushed as that value whereas expressions evaluating to multiple values are pushed as a list of produced values.