### PR TITLE
Add PROCEDURALLY for outputting procedure objects

### DIFF
--- a/lib/chibi/show/base.sld
+++ b/lib/chibi/show/base.sld
@@ -3,7 +3,8 @@
   (export
    show fn fn-fork with with! each each-in-list call-with-output
    displayed written written-shared written-simply numeric nothing
-   escaped maybe-escaped numeric/si numeric/fitted numeric/comma
+   escaped maybe-escaped procedurally
+   numeric/si numeric/fitted numeric/comma
    ;; internal
    output-default extract-shared-objects write-to-string write-with-shares
    call-with-shared-ref call-with-shared-ref/cdr)

--- a/lib/chibi/show/write.scm
+++ b/lib/chibi/show/write.scm
@@ -89,6 +89,17 @@
            (each quot (escaped str quot esc rename) quot)
            (displayed str))))))
 
+;;> Outputs \var{f} as a procedure object using \code{write}
+;;> semantics. This function is necessary to output procedures
+;;> as the combinator type is defined as not necessarily disjoint
+;;> from the procedure type.
+
+(define (procedurally f)
+  (fn ()
+    (let ((p (open-output-string)))
+      (write f p)
+      (get-output-string p))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; numeric formatting
 


### PR DESCRIPTION
Using `(chibi show)` or SRFI-159 is difficult for debugging due to the difficulty with which procedure objects are written. 