### PR TITLE
with-ellipsis

### DIFF
--- a/lib/chibi/syntax-case-test.sld
+++ b/lib/chibi/syntax-case-test.sld
@@ -47,4 +47,10 @@
 	    (syntax-case '((a b c) (d e f)) ()
 	      (((x ... y) ...) #'((x ...) ... y ...))))
 
+      (test "with-ellipsis"
+	    '((a b))
+	    (with-ellipsis :::
+	      (syntax-case '(a) ()
+		((... :::) #'((... b) :::)))))   
+
       (test-end))))

--- a/lib/chibi/syntax-case.sld
+++ b/lib/chibi/syntax-case.sld
@@ -3,7 +3,7 @@
 	  syntax-case syntax quasisyntax unsyntax unsyntax-splicing
 	  datum->syntax syntax->datum
 	  generate-temporaries with-syntax syntax-violation
-	  with-ellipsis)
+	  with-ellipsis ellipsis-identifier=?)
   (import (chibi)
 	  (chibi ast)
 	  (meta)

--- a/lib/chibi/syntax-case.sld
+++ b/lib/chibi/syntax-case.sld
@@ -2,7 +2,8 @@
   (export ... _ free-identifier=? bound-identifier=? identifier?
 	  syntax-case syntax quasisyntax unsyntax unsyntax-splicing
 	  datum->syntax syntax->datum
-	  generate-temporaries with-syntax syntax-violation)
+	  generate-temporaries with-syntax syntax-violation
+	  with-ellipsis)
   (import (chibi)
 	  (chibi ast)
 	  (meta)


### PR DESCRIPTION
This patch adds `with-ellipsis` and `ellipsis-identifier?` to the list of exported identifiers of `(chibi syntax-case)`.

The special form `(with-ellipsis E BODY ...)` makes the binding of the identifier E _the_ ellipsis in BODY. Macros can use `(ellipsis-identifier? ID)` to check whether ID is bound to the ellipsis in the usage environment.

The `with-ellipsis` keyword allows to implement the extensions of SRFI 46 to `syntax-rules` in terms of `syntax-case` and `syntax`:

```scheme
(define-syntax syntax-rules
  (lambda (stx)
    ((_ ellipsis (id* ...) ((keyword* . pattern*) template*) ...)
     (and (identifier? #'ellipsis) (every identifier? #'(id* ... keyword ...)))
     #'(let-syntax ((ellipsis #f))
         (with-ellipsis ellipsis
           (lambda (stx)
  	     (syntax-case stx (id* ...)
	       ((_ . pattern*) #'template*) ...))))
    ((_ (id* ...) ((keyword* . pattern*) template*) ...)
     (every identifier? #'(id* ... keyword ...))
     #'(lambda (stx)
	 (syntax-case stx (id* ...)
	   ((_ . pattern*) #'template*) ...)))))
```

See also 6.10.3.2 here: https://www.gnu.org/software/guile/manual/html_node/Syntax-Case.html.

(The idea of `with-ellipsis` is due to Guile's Mark H. Weaver.)