### PR TITLE
typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ install-base: all
 	$(INSTALL_EXE) -m0755 lib/srfi/98/env$(SO) $(DESTDIR)$(BINMODDIR)/srfi/98
 	$(INSTALL_EXE) -m0755 lib/srfi/144/math$(SO) $(DESTDIR)$(BINMODDIR)/srfi/144
 	$(INSTALL_EXE) -m0755 lib/srfi/151/bit$(SO) $(DESTDIR)$(BINMODDIR)/srfi/151
-	$(INSTALL_EXE) -m0755 lib/srfi/160/uvprim$(SO) $(DESTDIR)$(BINMODDIR)/srfi/160
+	$(INSTALL_EXE) -m0755 lib/srfi/160/uvprims$(SO) $(DESTDIR)$(BINMODDIR)/srfi/160
 	$(MKDIR) $(DESTDIR)$(INCDIR)
 	$(INSTALL) -m0644 $(INCLUDES) $(DESTDIR)$(INCDIR)/
 	$(MKDIR) $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
This PR fixes error on installing.

> install -m0755 lib/srfi/160/uvprim.so /home/aperez/.cache/yay/chibi-scheme-git/pkg/chibi-scheme-git/usr/lib/chibi/srfi/160
> install: cannot stat 'lib/srfi/160/uvprim.so': No such file or directory
> make: *** [Makefile:394: install-base] Error 1