### PR TITLE
Remove duplicate sys/sysctl.h inclusion

### DIFF
--- a/lib/chibi/signal.c
+++ b/lib/chibi/signal.c
@@ -63,7 +63,6 @@ static sexp sexp_set_signal_action (sexp ctx, sexp self, sexp signum, sexp newac
 #include <sys/time.h>
 #ifndef __DragonFly__
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/proc.h>
 #endif
 #include <sys/sysctl.h>


### PR DESCRIPTION
This removes a duplicate inclusion of `sys/sysctl.h` in `lib/chibi/signal.c` on BSD systems (excluding DragonFly).  At the bottom of the diff you can see that `sys/sysctl.h` is still included.  On DragonFly, `sysctl` is used in `sexp_pid_cmdline` so that's why I'm removing the former include.

Tested on OpenBSD:

$ uname -mrs
OpenBSD 6.4 amd64