### PR TITLE
Note that chibi works on OpenBSD in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ instructions on compiling with fewer features or requesting
 a smaller language on startup.
 
 Chibi-Scheme is known to work on **32** and **64-bit** Linux, FreeBSD,
-NetBSD and OS X, Plan 9, Windows (using Cygwin), iOS, Android, ARM and
-[Emscripten](https://kripken.github.io/emscripten-site).  Basic
+NetBSD, OpenBSD and OS X, Plan 9, Windows (using Cygwin), iOS, Android,
+ARM and [Emscripten](https://kripken.github.io/emscripten-site).  Basic
 support for native Windows desktop also exists. See README-win32.md
 for details and build instructions.
 


### PR DESCRIPTION
This simply lists OpenBSD as one of the operating systems that chibi is known to work on.  I have been building and using chibi on both 32-bit and 64-bit OpenBSD for over a year (in fact, I mentioned OpenBSD in my second PR almost a year ago: #463).

Chibi builds without errors and `gmake test` runs fine on the following:

$ uname -mrs
OpenBSD 6.4 amd64

$ uname -mrs
OpenBSD 6.4 i386

It just works without any extra steps.