### PR TITLE
Fix tests on Windows

### DIFF
--- a/sexp.c
+++ b/sexp.c
@@ -2280,7 +2280,7 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out) {
       break;
     }
   } else if (sexp_fixnump(obj)) {
-    snprintf(numbuf, NUMBUF_LEN, "%" SEXP_PRIdFIXNUM, (long)sexp_unbox_fixnum(obj));
+    snprintf(numbuf, NUMBUF_LEN, "%" SEXP_PRIdFIXNUM, (sexp_sint_t)sexp_unbox_fixnum(obj));
     sexp_write_string(ctx, numbuf, out);
 #if SEXP_USE_IMMEDIATE_FLONUMS
   } else if (sexp_flonump(obj)) {
@@ -2956,7 +2956,7 @@ sexp sexp_list_to_uvector_op(sexp ctx, sexp self, sexp_sint_t n, sexp etype, sex
     res = et == SEXP_U8 ? sexp_make_bytes(ctx, sexp_length(ctx, ls), SEXP_VOID) : sexp_make_uvector(ctx, etype, sexp_length(ctx, ls));
     min = 0;
     max = sexp_uvector_element_size(et) == 64 ? -1 :
-      (1uL << sexp_uvector_element_size(et)) - 1;
+      (1uLL << sexp_uvector_element_size(et)) - 1;
     if (sexp_uvector_prefix(et) == 's') {
       min = -(max/2) - 1;
       max = (max/2);


### PR DESCRIPTION
What this doesn't solve is the copious amount of warnings Visual Studio produces. The warnings are all for a good reason: The codebase doesn't seem to be able to decide whether it wants to represent things as `int` or `long` or `sexp_sint_t` or `sexp_uint_t` or `sexp_tag_t`, and the code is full of conversions from a larger type to a smaller one, or from unsigned to signed or vice-versa. This inevitably results in overflows like this: `max` overflowed to `0` when reading a `#u32(anything)`, and `(long)sexp_unbox_fixnum(obj)` overflowed to `4294967295` when `obj` represented a `-1`.

Would you be interested in me going over the codebase and fixing the warnings? This would mostly entail changing types of things to the correct types (such as from `long` to `sexp_sint_t`) where meaningful and adding explicit casts elsewhere.