### PR TITLE
Consider unterminated strings as read-error

### DIFF
--- a/lib/scheme/extras.scm
+++ b/lib/scheme/extras.scm
@@ -24,7 +24,7 @@
         (else (lp (cdr files) (append (read-sexps (car files) #t) res))))))))
 
 (define (read-error? x)
-  (and (error-object? x) (eq? 'read (exception-kind x))))
+  (and (error-object? x) (memq (exception-kind x) '(read read-incomplete)) #t))
 
 (define (file-error? x)
   (and (error-object? x) (eq? 'file (exception-kind x))))

--- a/tests/r7rs-tests.scm
+++ b/tests/r7rs-tests.scm
@@ -1778,6 +1778,8 @@
     (read-error? (guard (exn (else exn)) (error "BOOM!"))))
 (test #t
     (read-error? (guard (exn (else exn)) (read (open-input-string ")")))))
+(test #t
+    (read-error? (guard (exn (else exn)) (read (open-input-string "\"")))))
 
 (define something-went-wrong #f)
 (define (test-exception-handler-1 v)


### PR DESCRIPTION
I expect the following to return `#t`, however it returns `#f`. This PR fixes this by considering both errors of the `read` and `read-incomplete` kind as `read-error`.

```scheme
(read-error? (guard (exn (else exn)) (read (open-input-string "\""))))
```