### PR TITLE
Fix include-shared for process

### DIFF
--- a/lib/chibi/process.sld
+++ b/lib/chibi/process.sld
@@ -19,5 +19,5 @@
           process->output+error process->output+error+status)
   (import (chibi) (chibi io) (chibi string) (chibi filesystem))
   (cond-expand (threads (import (srfi 18) (srfi 151))) (else #f))
-  (cond-expand (windows) (else (include-shared "process")))
+  (cond-expand ((not windows) (include-shared "process")))
   (include "process.scm"))


### PR DESCRIPTION
`chibi-genstatic` doesn't support expansion of `cond-expand` when the pattern is `(cond-expand (cond) (else (include-shared "module")))`