### PR TITLE
build on Solaris-like systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,11 @@ XLDFLAGS  := $(LDFLAGS) $(RLDFLAGS) $(GCLDFLAGS) $(LIBDL) -lm
 XCFLAGS   := -Wall -g -g3 -O3 $(CFLAGS)
 endif
 
+ifeq ($(PLATFORM),solaris)
+XLDFLAGS += -lsocket
+XCPPFLAGS += -D_POSIX_PTHREAD_SEMANTICS
+endif
+
 ########################################################################
 
 all: chibi-scheme$(EXE) all-libs chibi-scheme.pc $(META_FILES)

--- a/Makefile.detect
+++ b/Makefile.detect
@@ -35,7 +35,11 @@ else
 ifeq ($(shell uname -o),GNU/Linux)
 PLATFORM=linux
 else
+ifeq ($(shell uname),SunOS)
+PLATFORM=solaris
+else
 PLATFORM=unix
+endif
 endif
 endif
 endif
@@ -70,6 +74,14 @@ EXE =
 CLIBFLAGS = -fPIC
 CLINKFLAGS = -shared
 LIBDL = 
+RLDFLAGS=-Wl,-R$(LIBDIR)
+else
+ifeq ($(PLATFORM),solaris)
+SO = .so
+EXE =
+CLIBFLAGS = -fPIC
+CLINKFLAGS = -shared
+LIBDL = -ldl
 RLDFLAGS=-Wl,-R$(LIBDIR)
 else
 ifeq ($(PLATFORM),windows)
@@ -107,6 +119,7 @@ CLIBFLAGS = -fPIC
 CLINKFLAGS = -shared
 STATICFLAGS = -static -DSEXP_USE_DL=0
 LIBCHIBI_FLAGS = -Wl,-soname,libchibi-scheme$(SO).$(SOVERSION_MAJOR)
+endif
 endif
 endif
 endif

--- a/lib/chibi/time.sld
+++ b/lib/chibi/time.sld
@@ -5,9 +5,12 @@
           make-timeval make-tm timeval-seconds timeval-microseconds
           timezone-offset timezone-dst-time
           time-second time-minute time-hour time-day time-month time-year
-          time-day-of-week time-day-of-year time-dst? time-timezone-name
-          time-offset
+          time-day-of-week time-day-of-year time-dst?
           tm? timeval? timezone?)
+  (cond-expand
+   (solaris)
+   (else
+    (export time-offset time-timezone-name)))
   (cond-expand
    (emscripten)
    (else

--- a/lib/chibi/time.stub
+++ b/lib/chibi/time.stub
@@ -7,21 +7,37 @@
   (c-system-include "time.h")
   (c-system-include "sys/time.h")))
 
-(define-c-struct tm
-  predicate: tm?
-  constructor: (make-tm tm_sec tm_min tm_hour
-                tm_mday tm_mon tm_year tm_isdst)
-  (int     tm_sec    time-second)
-  (int     tm_min    time-minute)
-  (int     tm_hour   time-hour)
-  (int     tm_mday   time-day)
-  (int     tm_mon    time-month)
-  (int     tm_year   time-year)
-  (int     tm_wday   time-day-of-week)
-  (int     tm_yday   time-day-of-year)
-  (int     tm_isdst  time-dst?)
-  (string  tm_zone   time-timezone-name)
-  (int     tm_gmtoff time-offset))
+(cond-expand
+ (solaris
+    (define-c-struct tm
+    predicate: tm?
+    constructor: (make-tm tm_sec tm_min tm_hour
+                          tm_mday tm_mon tm_year tm_isdst)
+    (int     tm_sec    time-second)
+    (int     tm_min    time-minute)
+    (int     tm_hour   time-hour)
+    (int     tm_mday   time-day)
+    (int     tm_mon    time-month)
+    (int     tm_year   time-year)
+    (int     tm_wday   time-day-of-week)
+    (int     tm_yday   time-day-of-year)
+    (int     tm_isdst  time-dst?)))
+ (else
+  (define-c-struct tm
+    predicate: tm?
+    constructor: (make-tm tm_sec tm_min tm_hour
+                          tm_mday tm_mon tm_year tm_isdst)
+    (int     tm_sec    time-second)
+    (int     tm_min    time-minute)
+    (int     tm_hour   time-hour)
+    (int     tm_mday   time-day)
+    (int     tm_mon    time-month)
+    (int     tm_year   time-year)
+    (int     tm_wday   time-day-of-week)
+    (int     tm_yday   time-day-of-year)
+    (int     tm_isdst  time-dst?)
+    (string  tm_zone   time-timezone-name)
+    (int     tm_gmtoff time-offset))))
 
 ;;> Accessors for the \scheme{tm} struct.
 ;;/


### PR DESCRIPTION
This lets you build on illumos or Solaris.  I'm not sure if any of it is really done correctly.

We need to link to `libsocket` for `shutdown` and define `_POSIX_PTHREAD_SEMANTICS` to get the right versions of `asctime_r` and such.  Add a `PLATFORM` "solaris" to condition those.

time has no tm_zone or tm_gmtoff, so they are conditionalized and not present.  They could also be supplied in a Solaris-y manner, but I don't know how to arrange for the stub file to generate an arbitrary function.