### PR TITLE
Fix NetBSD, DragonFly BSD and Darwin feature detection

### DIFF
--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -323,14 +323,12 @@
 #define SEXP_NETBSD 1
 #define SEXP_DRAGONFLY 0
 #define SEXP_OPENBSD 0
-#define SEXP_NETBSD 0
 #elif defined(__DragonFly__)
-#define SEXP_DARWIN 1
+#define SEXP_DARWIN 0
 #define SEXP_FREEBSD 0
 #define SEXP_NETBSD 0
 #define SEXP_DRAGONFLY 1
 #define SEXP_OPENBSD 0
-#define SEXP_DRAGONFLY 0
 #elif defined(__OpenBSD__)
 #define SEXP_DARWIN 0
 #define SEXP_FREEBSD 0


### PR DESCRIPTION
On NetBSD systems the `netbsd` feature identifier was not actually provided because the macro `SEXP_NETBSD` was defined twice and the second value was 0.

On DragonFly systems the `dragonfly` feature identifier was not actually provided because the macro `SEXP_DRAGONFLY` was defined twice and the second value was 0.  Also on DragonFly systems the `darwin` feature identifier was incorrectly provided because `SEXP_DARWIN` had a value of 1 instead of 0.

Tested on OpenBSD, NetBSD and DragonFly BSD.  The corresponding defines that are already present for Darwin and FreeBSD look correct.