### PR TITLE
(chibi pty): fix compilation errors on the BSDs

### DIFF
--- a/lib/chibi/pty.stub
+++ b/lib/chibi/pty.stub
@@ -1,8 +1,10 @@
 
 (cond-expand
- (macosx (c-system-include "util.h"))
+ ((or macosx openbsd netbsd) (c-system-include "util.h"))
+ ((or freebsd dragonfly) (c-system-include "libutil.h"))
  (else (c-system-include "pty.h")))
-(c-system-include "utmp.h")
+(cond-expand
+ ((not bsd) (c-system-include "utmp.h")))
 
 (c-link "util")
 


### PR DESCRIPTION
Some changes are necessary to fix compilation on the BSDs:

- Include `util.h` instead of `pty.h` on OpenBSD and NetBSD.

- Include `libutil.h` instead of `pty.h` on FreeBSD and DragonFly BSD.  DragonFly actually has both `util.h` and `libutil.h`, but the man pages say `libutil.h` so that's what I went with.

- Include `utmp.h` only on non-BSD systems (FreeBSD does not have that header and none of these BSDs require it).  I don't know if we can get away with including it only on Linux, so I stuck to non-BSD.

I tested on all four of these BSDs.

See also #558 