### PR TITLE
(chibi pty): Disable in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,8 @@ if(WIN32)
         lib/chibi/process.sld
         lib/chibi/stty.sld
         lib/chibi/system.sld
-        lib/chibi/time.sld)
+        lib/chibi/time.sld
+        lib/chibi/pty.sld)
 endif()
 
 #
@@ -294,6 +295,7 @@ set(testexcludes
     chibi/system-test
     chibi/tar-test # Depends (chibi system)
     chibi/process-test # Not applicable
+    chibi/pty-test # Depends (chibi pty)
     )
 
 set(testlibs)


### PR DESCRIPTION
Disable `(chibi pty)` build with CMake.

Unfortunately, AppVeyor doesn't have any support to "watch" CI on another account. Feel free call/assign me anytime if you have any issue on AppVeyor build...

FWIW, [Windows will support PTY soon](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/) but I don't think it's worth to add it as Windows does not support the other essential POSIX feature -- `fork` .