### PR TITLE
(chibi process): fix process-running? on OpenBSD, NetBSD and DragonFly

### DIFF
--- a/lib/chibi/process-test.sld
+++ b/lib/chibi/process-test.sld
@@ -6,6 +6,7 @@
       (test-begin "processes")
       (test #t (process-running? (current-process-id)))
       (test #t (process-running? (parent-process-id)))
+      (test #f (process-running? -1))
       (test #f (signal-set-contains? (current-signal-mask) signal/alarm))
       (test #t (signal-set? (make-signal-set)))
       (test #t (signal-set? (current-signal-mask)))

--- a/lib/chibi/signal.c
+++ b/lib/chibi/signal.c
@@ -83,8 +83,14 @@ static sexp sexp_pid_cmdline (sexp ctx, int pid) {
   int id = KERN_PROC;
 #endif
   size_t reslen = sizeof(res);
+#if defined(__NetBSD__) || defined(__OpenBSD__)
+  int name[6] = {CTL_KERN, id, KERN_PROC_PID, pid, reslen, 1};
+  unsigned namelen = 6;
+#else
   int name[4] = {CTL_KERN, id, KERN_PROC_PID, pid};
-  if (sysctl(name, 4, &res, &reslen, NULL, 0) >= 0) {
+  unsigned namelen = 4;
+#endif
+  if (sysctl(name, namelen, &res, &reslen, NULL, 0) >= 0 && reslen > 0) {
 #if defined(__APPLE__)
     return sexp_c_string(ctx, res.kp_proc.p_comm, -1);
 #elif defined(__NetBSD__) || defined(__OpenBSD__)


### PR DESCRIPTION
`process-running?` would always return `#f` on OpenBSD and NetBSD, and in the one-argument case it would always return `#t` on DragonFly BSD.

So on OpenBSD and NetBSD we would have things like

  `(process-running? 1)` => `#f`
  `(process-running? (current-process-id))` => `#f`

and so on.

Then on DragonFly (and OpenBSD and NetBSD after fixing the above) we would have things like

  `(process-running? -1)` => `#t`
  `(process-running? <other nonexistent pid>)` => `#t`

and so on.

`process-running?` worked fine on FreeBSD.

My commit message gives the details of the problems and the fixes.

I also add a test to check that `(process-running? -1)` => `#f` now.

Tested on OpenBSD, NetBSD, DragonFly and FreeBSD.  All of the `process-test` tests now pass on all of these.