### PR TITLE
(chibi net): sockaddr-port: return the port number in host byte order

### DIFF
--- a/lib/chibi/accept.c
+++ b/lib/chibi/accept.c
@@ -106,5 +106,5 @@ sexp sexp_sockaddr_name (sexp ctx, sexp self, struct sockaddr* addr) {
 
 int sexp_sockaddr_port (sexp ctx, sexp self, struct sockaddr* addr) {
   struct sockaddr_in *sa = (struct sockaddr_in *)addr;
-  return sa->sin_port;
+  return ntohs(sa->sin_port);
 }


### PR DESCRIPTION
I expected the following to give me 22, but in this case it was being given to me in the wrong byte order:

```
> (sockaddr-port (address-info-address (get-address-info "localhost" 22)))
5632
```