### PR TITLE
(chibi net): sockaddr-name: fix support for IPv6 addresses

### DIFF
--- a/lib/chibi/accept.c
+++ b/lib/chibi/accept.c
@@ -92,7 +92,7 @@ sexp sexp_listen (sexp ctx, sexp self, sexp fileno, sexp backlog) {
 /* Additional utilities. */
 
 sexp sexp_sockaddr_name (sexp ctx, sexp self, struct sockaddr* addr) {
-  char buf[24];
+  char buf[INET6_ADDRSTRLEN];
   /* struct sockaddr_in *sa = (struct sockaddr_in *)addr; */
   /* unsigned char *ptr = (unsigned char *)&(sa->sin_addr); */
   /* sprintf(buf, "%d.%d.%d.%d", ptr[0], ptr[1], ptr[2], ptr[3]); */
@@ -100,7 +100,7 @@ sexp sexp_sockaddr_name (sexp ctx, sexp self, struct sockaddr* addr) {
             (addr->sa_family == AF_INET6 ?
              (void*)(&(((struct sockaddr_in6 *)addr)->sin6_addr)) :
              (void*)(&(((struct sockaddr_in *)addr)->sin_addr))),
-            buf, 24);
+            buf, INET6_ADDRSTRLEN);
   return sexp_c_string(ctx, buf, -1);
 }
 


### PR DESCRIPTION
The buffer was too small to hold all IPv6 addresses in string form.  `INET6_ADDRSTRLEN` is the standard constant giving the required length to hold these addresses.