### PR TITLE
(chibi net): make-listener-socket: close the socket on error

### DIFF
--- a/lib/chibi/net.scm
+++ b/lib/chibi/net.scm
@@ -90,6 +90,7 @@
      ((not sock)
       (error "couldn't create socket for: " addrinfo))
      ((not (set-socket-option! sock level/socket socket-opt/reuseaddr 1))
+      (close-file-descriptor sock)
       (error "couldn't set the socket to be reusable" addrinfo))
      ((not (bind sock
                  (address-info-address addrinfo)


### PR DESCRIPTION
A socket was leaked in the case where setting `socket-opt/reuseaddr` failed.  (The socket was already being closed in the other cases where `bind` or `listen` failed.)