### PR TITLE
memv: compare using eqv? instead of equal?

### DIFF
--- a/lib/init-7.scm
+++ b/lib/init-7.scm
@@ -676,7 +676,7 @@
     (let lp ((ls ls))
       (and (pair? ls) (if (eq obj (car ls)) ls (lp (cdr ls)))))))
 
-(define memv member)
+(define (memv obj ls) (member obj ls eqv?))
 
 (define (assoc obj ls . o)
   (let ((eq (if (pair? o) (car o) equal?)))


### PR DESCRIPTION
`memv` has been defined to be `member`, so it has been comparing using `equal?` (by default) instead of `eqv?`.

Now with this commit `memv` calls `member` with the optional argument of `eqv?`.  This is analogous to how `assv` is defined to call `assoc` with the optional argument of `eqv?`.

See also #242 and commit 4d0daf5df4ebbea19fc2e9becf2fbc822a5901b2.