### PR TITLE
(chibi net server-util): file-mime-type: fix load-mime-types call

### DIFF
--- a/lib/chibi/net/server-util.scm
+++ b/lib/chibi/net/server-util.scm
@@ -75,9 +75,9 @@
       (if (not ext-types)
           (let ((ht (make-hash-table eq?)))
             (cond
-             ((any file-exists? '("/etc/mime.types"
-                                  "/etc/httpd/mime.types"
-                                  "/etc/apache2/mime.types"))
+             ((find file-exists? '("/etc/mime.types"
+                                   "/etc/httpd/mime.types"
+                                   "/etc/apache2/mime.types"))
               => (lambda (file) (load-mime-types ht file))))
             (set! ext-types ht)))
       (let* ((ext (path-extension file))


### PR DESCRIPTION
Use `find` instead of `any` so `load-mime-types` will get the filename instead of `#t` when a mime.types file is found.  Otherwise an error occurs in `load-mime-types`.

Before:

```
> (file-mime-type "foo.txt")
couldn't load mime types from #t
ERROR in "open-input-file": invalid type, expected String: #t
"application/octet-stream"
> (file-mime-type "foo.jpg")
"application/octet-stream"
```

and after (with the `/etc/mime.types` on this box):

```
> (file-mime-type "foo.txt")
"text/plain"
> (file-mime-type "foo.jpg")
"image/jpeg"
```