### PR TITLE
Fixes for mmapped heaps

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -500,7 +500,7 @@ sexp_heap sexp_make_heap (size_t size, size_t max_size, size_t chunk_size) {
   sexp_free_list free, next;
   sexp_heap h;
 #if SEXP_USE_MMAP_GC
-  h =  mmap(NULL, sexp_heap_pad_size(size), PROT_READ|PROT_WRITE|PROT_EXEC,
+  h =  mmap(NULL, sexp_heap_pad_size(size), PROT_READ|PROT_WRITE,
             MAP_ANON|MAP_PRIVATE, -1, 0);
   if (h == MAP_FAILED) return NULL;
 #else

--- a/gc.c
+++ b/gc.c
@@ -501,7 +501,7 @@ sexp_heap sexp_make_heap (size_t size, size_t max_size, size_t chunk_size) {
   sexp_heap h;
 #if SEXP_USE_MMAP_GC
   h =  mmap(NULL, sexp_heap_pad_size(size), PROT_READ|PROT_WRITE|PROT_EXEC,
-            MAP_ANON|MAP_PRIVATE, 0, 0);
+            MAP_ANON|MAP_PRIVATE, -1, 0);
   if (h == MAP_FAILED) return NULL;
 #else
   h =  sexp_malloc(sexp_heap_pad_size(size));

--- a/gc.c
+++ b/gc.c
@@ -502,10 +502,11 @@ sexp_heap sexp_make_heap (size_t size, size_t max_size, size_t chunk_size) {
 #if SEXP_USE_MMAP_GC
   h =  mmap(NULL, sexp_heap_pad_size(size), PROT_READ|PROT_WRITE|PROT_EXEC,
             MAP_ANON|MAP_PRIVATE, 0, 0);
+  if (h == MAP_FAILED) return NULL;
 #else
   h =  sexp_malloc(sexp_heap_pad_size(size));
-#endif
   if (! h) return NULL;
+#endif
   h->size = size;
   h->max_size = max_size;
   h->chunk_size = chunk_size;


### PR DESCRIPTION
Here are a few fixes for mmapped heaps (`SEXP_USE_MMAP_GC=1`).  On the BSDs, a segfault was always occurring due to `mmap` failing and the return value not being correctly checked.

- `mmap` returns `MAP_FAILED` on error, not `NULL`.  POSIX does not define the value of `MAP_FAILED`, but on at least the BSDs and Linux its value is `((void *) -1)`

- Fix for the BSDs: the file descriptor passed to `mmap` when using `MAP_ANON` must be -1.  Passing 0 causes `mmap` to fail.

- Fix for systems with W^X policies: the heap does not need to be executable, so just make it read/write instead of read/write/exec.  OpenBSD and NetBSD have W^X policies by default that cause `mmap` to fail when using read/write/exec.

Tested on OpenBSD, NetBSD, FreeBSD, Dragonfly BSD and Linux.  Now everything builds fine and `make test` passes on all of them when `SEXP_USE_MMAP_GC=1`.