### PR TITLE
Fix incorrect and syntax

### DIFF
--- a/lib/init-7.scm
+++ b/lib/init-7.scm
@@ -213,7 +213,7 @@
 (define-syntax and
   (er-macro-transformer
    (lambda (expr rename compare)
-     (cond ((null? (cdr expr)))
+     (cond ((null? (cdr expr)) #t)
            ((null? (cddr expr)) (cadr expr))
            (else (list (rename 'if) (cadr expr)
                        (cons (rename 'and) (cddr expr))


### PR DESCRIPTION
According to R7RS 4.2.1, the and syntax with no arguments is correct to return true.