### PR TITLE
(chibi show): Make ANSI escape codes work with col state variable

### DIFF
--- a/lib/chibi/show-test.sld
+++ b/lib/chibi/show-test.sld
@@ -739,6 +739,10 @@ def | 6
           (show #f (with ((pad-char #\〜)) (padded/both 5 "日本語"))))
       (test "日本語"
             (show #f (as-unicode (with ((pad-char #\〜)) (padded/both 5 "日本語")))))
+      (test "\x1b;[31m1234567\x1b;[0m col: 7"
+            (show #f (as-unicode (as-red "1234567") (fn ((col)) (each " col: " col)))))
+      (test "日本語 col: 6"
+            (show #f (as-unicode "日本語" (fn ((col)) (each " col: " col)))))
 
       ;; from-file
       ;; for reference, filesystem-test relies on creating files under /tmp

--- a/lib/chibi/show-test.sld
+++ b/lib/chibi/show-test.sld
@@ -733,14 +733,14 @@ def | 6
       (test "\x1B;[31mred\x1B;[0m" (show #f (as-red "red")))
       (test "\x1B;[31mred\x1B;[34mblue\x1B;[31mred\x1B;[0m"
           (show #f (as-red "red" (as-blue "blue") "red")))
+      (test "\x1b;[31m1234567\x1b;[0m col: 7"
+            (show #f (as-unicode (as-red "1234567") (fn ((col)) (each " col: " col)))))
 
       ;; unicode
       (test "〜日本語〜"
           (show #f (with ((pad-char #\〜)) (padded/both 5 "日本語"))))
       (test "日本語"
             (show #f (as-unicode (with ((pad-char #\〜)) (padded/both 5 "日本語")))))
-      (test "\x1b;[31m1234567\x1b;[0m col: 7"
-            (show #f (as-unicode (as-red "1234567") (fn ((col)) (each " col: " col)))))
       (test "日本語 col: 6"
             (show #f (as-unicode "日本語" (fn ((col)) (each " col: " col)))))
 

--- a/lib/chibi/show/color.scm
+++ b/lib/chibi/show/color.scm
@@ -18,7 +18,7 @@
     (else "0")))
 
 (define (ansi-escape color)
-  (each (integer->char 27) "[" (color->ansi color) "m"))
+  (string-append (string (integer->char 27)) "[" (color->ansi color) "m"))
 
 (define (colored new-color . args)
   (fn (color)


### PR DESCRIPTION
The `col` state variable is increased by `output-default` in `(chibi show base)` every time it receives a chunk of formatted text. This is fine as long as `output-default` never receives a fragment of an ANSI escape code or Unicode char. Unfortunately, `(chibi show color)` uses `each` to construct escape sequences breaking this assumption.

For example,
```scheme
(show #f (as-unicode (as-red "1234567") (fn ((col)) (each " col: " col))))
```
evaluates to `"\x1b;[31m1234567\x1b;[0m col: 16"` rather than `"\x1b;[31m1234567\x1b;[0m col: 7"`.

This PR changes the `ansi-escape` procedure of `(chibi show color)` to return a single string rather than a  composite formatter.