### PR TITLE
Fix make-comparator hash function arity in SRFI 128

### DIFF
--- a/lib/srfi/128.sld
+++ b/lib/srfi/128.sld
@@ -1,7 +1,8 @@
 (define-library (srfi 128)
   (import (scheme base) (scheme char)
           (srfi 27) (srfi 69) (srfi 95) (srfi 98) (srfi 151)
-          (only (chibi) fixnum? er-macro-transformer))
+          (only (chibi) fixnum? er-macro-transformer)
+          (only (chibi ast) opcode? procedure? procedure-arity procedure-variadic?))
   (export
    ;; Predicates:
    comparator? comparator-ordered? comparator-hashable?

--- a/lib/srfi/128/comparators.scm
+++ b/lib/srfi/128/comparators.scm
@@ -1,11 +1,23 @@
 
 (define-record-type Comparator
-  (make-comparator type-test equality ordering hash)
+  (%make-comparator% type-test equality ordering hash)
   comparator?
   (type-test comparator-type-test-predicate)
   (equality comparator-equality-predicate)
   (ordering comparator-ordering-predicate)
   (hash comparator-hash-function))
+
+(define (make-comparator type-test equality ordering hash)
+  (%make-comparator%
+    type-test
+    equality
+    ordering
+    (if (or (opcode? hash)
+            (not (procedure? hash))
+            (procedure-variadic? hash)
+            (> (procedure-arity hash) 1))
+        hash
+        (lambda (x . o) (hash x)))))
 
 (define-syntax hash-bound
   (er-macro-transformer


### PR DESCRIPTION
This resolves issue #531: SRFI 125 functions would sometimes crash when using SRFI 128 comparators with single-argument hash functions, because SRFI 125 is based on SRFI 69, which expects two-argument hash functions.

This PR resolves the issue by changing `make-comparator` to wrap single-argument hash functions in a lambda that takes and ignores a second argument. It uses `(chibi ast)` to detect functions that could accept two arguments, so that it doesn't unnecessarily wrap them and remove any functionality from the second argument.