### PR TITLE
Common library installation prefixes

### DIFF
--- a/Makefile.libs
+++ b/Makefile.libs
@@ -30,10 +30,10 @@ LDCONFIG  ?= ldconfig
 PREFIX    ?= /usr/local
 BINDIR    ?= $(PREFIX)/bin
 LIBDIR    ?= $(PREFIX)/lib
-SOLIBDIR  ?= $(PREFIX)/lib
+SOLIBDIR  ?= $(LIBDIR)
 INCDIR    ?= $(PREFIX)/include/chibi
 MODDIR    ?= $(PREFIX)/share/chibi
-BINMODDIR ?= $(PREFIX)/lib/chibi
+BINMODDIR ?= $(SOLIBDIR)/chibi
 PKGCONFDIR ?= $(SOLIBDIR)/pkgconfig
 MANDIR    ?= $(PREFIX)/share/man/man1
 


### PR DESCRIPTION
Both SOLIBDIR and BINMODDIR install into $(PREFIX)/lib which is the same value as LIBDIR -- the traditional name of the directory for installed libraries. Current duplication is fine for the default installation (with PREFIX=/usr/local) but it does not play nicely with systems supporting multiple architectures.

For example, Debian systems allow the users to install libraries for multiple architectures simultaneously: e.g., 32-bit and 64-bit libraries for AMD-64 CPUs go into separate directories:

  - 64-bit: `/usr/lib/x86_64-linux-gnu/libchibi-scheme.so.0.8.0`
  - 32-bit: `/usr/lib/i386-linux-gnu/libchibi-scheme.so.0.8.0`

Other Linux systems (Red Hat family) use different paths like `/usr/lib64` and `/usr/lib`, but the general idea is the same.

In order to achieve this, packaging toolchain supplies appropriate value of LIBDIR which takes care of these details more or less automagically.

However, with Chibi you currently need to additionally override SOLIBDIR and BINMODDIR to have all the libraries installed into multiarch-enabled locations. While definitely doable, it's not convenient.

Redefine SOLIBDIR and BINMODDIR in terms of LIBDIR so that you only need to override LIBDIR to get the packaging correctly. This does not change the default installation paths and it is still possible to override these values individually if necessary.