### PR TITLE
Correct man page installation directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,10 +408,10 @@ install-base: all
 	-if test -f libchibi-scheme.a; then $(INSTALL) -m0644 libchibi-scheme.a $(DESTDIR)$(SOLIBDIR)/; fi
 	$(MKDIR) $(DESTDIR)$(PKGCONFDIR)
 	$(INSTALL) -m0644 chibi-scheme.pc $(DESTDIR)$(PKGCONFDIR)
-	$(MKDIR) $(DESTDIR)$(MANDIR)
-	$(INSTALL) -m0644 doc/chibi-scheme.1 $(DESTDIR)$(MANDIR)/
-	$(INSTALL) -m0644 doc/chibi-ffi.1 $(DESTDIR)$(MANDIR)/
-	$(INSTALL) -m0644 doc/chibi-doc.1 $(DESTDIR)$(MANDIR)/
+	$(MKDIR) $(DESTDIR)$(MANDIR)/man1
+	$(INSTALL) -m0644 doc/chibi-scheme.1 $(DESTDIR)$(MANDIR)/man1/
+	$(INSTALL) -m0644 doc/chibi-ffi.1 $(DESTDIR)$(MANDIR)/man1/
+	$(INSTALL) -m0644 doc/chibi-doc.1 $(DESTDIR)$(MANDIR)/man1/
 	-if type $(LDCONFIG) >/dev/null 2>/dev/null; then $(LDCONFIG); fi
 
 install: install-base


### PR DESCRIPTION
According to the Filesystem Hierarchy Standard (see `man 7 hier`) man pages should be installed into an appropriate subdirectory for their section. Fix the installation path so that our documentation goes into the right place.

All UNIX-like systems supported by Chibi follow FHS for man pages:

  - FreeBSD
  - GNU/Linux
  - macOS
  - Plan 9