### PR TITLE
Always install Snow libraries to /usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ chibi-scheme-emscripten: VERSION
 
 include/chibi/install.h: Makefile
 	echo '#define sexp_so_extension "'$(SO)'"' > $@
-	echo '#define sexp_default_module_path "'$(MODDIR):$(BINMODDIR)'"' >> $@
+	echo '#define sexp_default_module_path "'$(MODDIR):$(BINMODDIR):$(SNOWMODDIR):$(SNOWBINMODDIR)'"' >> $@
 	echo '#define sexp_platform "'$(PLATFORM)'"' >> $@
 	echo '#define sexp_version "'$(VERSION)'"' >> $@
 	echo '#define sexp_release_name "'`cat RELEASE`'"' >> $@

--- a/Makefile.libs
+++ b/Makefile.libs
@@ -37,6 +37,12 @@ BINMODDIR ?= $(PREFIX)/lib/chibi
 PKGCONFDIR ?= $(SOLIBDIR)/pkgconfig
 MANDIR    ?= $(PREFIX)/share/man/man1
 
+SNOWPREFIX    ?= /usr/local
+SNOWLIBDIR    ?= $(SNOWPREFIX)/lib
+SNOWSOLIBDIR  ?= $(SNOWLIBDIR)
+SNOWMODDIR    ?= $(SNOWPREFIX)/share/snow
+SNOWBINMODDIR ?= $(SNOWSOLIBDIR)/snow
+
 DESTDIR   ?=
 
 ########################################################################


### PR DESCRIPTION
Snow-Chibi is a local package manager, not a system one. It can install Scheme packages into system but they are not managed by system package manager like dpkg, RPM, pacman, ports, etc.

Traditionally (and in accordance with Filesystem Hierarchy Standard), /usr/local hierarchy should be used for local administrator installs -- and that's what Snow-Chibi provides.

Let's make sure that Snow-Chibi installs snowballs into /usr/local hierarchy even if Chibi is compiled for installation into the system, with PREFIX=/usr. Introduce a distinct bunch of variables holding paths to library installation directories, with "SNOW" prefix:

  - SNOWPREFIX    - default prefix for Snow-installed stuff
  - SNOWLIBDIR    - custom libraries required for Snow itself
  - SNOWSOLIBDIR  - shared libraries required for Snow itself
  - SNOWMODDIR    - Snow installs Scheme modules here
  - SNOWBINMODDIR - Snow installs native libraries here

All of these are set to /use/local by default, just as they are now. However, they are not affected by regular PREFIX, LIBDIR, MODDIR, etc. which affect only libraries bundled with Chibi.

And in order for these to work, they need to be added into the current module path so that they can be used in parallel with system libraries. Furthermore, we need to tweak `get-install-library-dir` function to use those paths instead of hardcoded `"/usr/local/lib"` by default. Introduce a new helper `get-install-library-dirs`, similar to `get-install-dirs`. It will look up the correct installation directories in current module path, giving preference to the ones with `/lib` in them.

With these defaults, Snow will install Scheme modules into `/usr/local/share/snow` and native libraries go into `/usr/local/lib/snow`, similar to how built-it libraries are installed into `/usr/local/share/chibi` and `/usr/local/lib/chibi` is used for native code. Of course, this can be overridden at build time by setting SNOWPREFIX or individual SNOWMODDIR, SNOWBINMODDIR variables.