### PR TITLE
Hide unnecessarily exported symbols

### DIFF
--- a/gc_heap.c
+++ b/gc_heap.c
@@ -7,7 +7,7 @@
 #if SEXP_USE_IMAGE_LOADING
 
 #define ERR_STR_SIZE 256
-char gc_heap_err_str[ERR_STR_SIZE];
+static char gc_heap_err_str[ERR_STR_SIZE];
 
 
 static sexp_uint_t sexp_gc_allocated_bytes (sexp ctx, sexp *types, size_t types_cnt, sexp x) {
@@ -573,7 +573,7 @@ static sexp load_image_callback_p2 (sexp ctx, sexp dstp, void *user) {
 }
 
 
-int load_image_header(FILE *fp, struct sexp_image_header_t* header) {
+static int load_image_header(FILE *fp, struct sexp_image_header_t* header) {
   if (!fp || !header) { return 0; }
   
   if (fread(header, sizeof(struct sexp_image_header_t), 1, fp) != 1) {


### PR DESCRIPTION
`gc_heap_err_str` and `load_image_header()` are never used outside of **gc_heap.c** but they are not marked static and are effectively exported by Chibi's shared library. Since this is unlikely to be intentional, let's hide them.

[include/chibi/sexp-hufftabs.c](https://github.com/ashinn/chibi-scheme/blob/2b7927b9bc72cd4ac10ee3fc3fef0180c738f96b/include/chibi/sexp-hufftabs.c) has several more symbols which end up exported from Chibi's shared library. However, they are a bit tricky. It's not possible to simply slap a `static` on them because they are [used by SRFI 95](https://github.com/ashinn/chibi-scheme/blob/2b7927b9bc72cd4ac10ee3fc3fef0180c738f96b/lib/srfi/95/qsort.c#L11-L17) whose native library expects them to be exported from Chibi objects when building a static library. It's possible to get the correct behavior with GCC/Clang's visibility attribute -- we want the symbols visible when linking a static library, but not exported from a shared one -- however, I'm not able to test that on Windows at the moment, and this will require some platform detection logic, so it's not in this PR.