### PR TITLE
Correct srfi-159 exported procedures

### DIFF
--- a/lib/srfi/159.sld
+++ b/lib/srfi/159.sld
@@ -5,7 +5,7 @@
   (export
    ;; base
    show fn forked with with! each each-in-list call-with-output
-   displayed written written-shared written-simply
+   displayed written written-simply pretty pretty-simply
    numeric numeric/comma numeric/si numeric/fitted
    nothing nl fl space-to tab-to escaped maybe-escaped
    padded padded/right padded/both

--- a/lib/srfi/159/base.sld
+++ b/lib/srfi/159/base.sld
@@ -1,9 +1,9 @@
 
 (define-library (srfi 159 base)
-  (import (chibi show))
+  (import (chibi show) (chibi show pretty))
   (export
    show fn forked with with! each each-in-list call-with-output
-   displayed written written-shared written-simply
+   displayed written written-simply pretty pretty-simply
    numeric numeric/comma numeric/si numeric/fitted
    nothing nl fl space-to tab-to escaped maybe-escaped
    padded padded/right padded/both


### PR DESCRIPTION
The two procedures pretty and pretty-simply from (chibi show pretty)
should be part of (srfi 159 base). written-shared is removed from 159
because it looks like it's an addition in 166.