### PR TITLE
chibi/test: remove dead import

### DIFF
--- a/lib/chibi/test.sld
+++ b/lib/chibi/test.sld
@@ -17,7 +17,7 @@
           (chibi term ansi))
   (cond-expand
    (chibi
-    (import (only (chibi) pair-source print-exception protect)))
+    (import (only (chibi) pair-source print-exception)))
    (chicken
     (import (only (chicken) print-error-message))
     (begin


### PR DESCRIPTION
'protect' used to be renamed to 'guard', after excluding 'guard'
from (scheme base). But that part is now gone. test.scm itself never
uses 'protect' directly. Remove it because it's not used.