### PR TITLE
Allow to run chibi-run from anywhere

### DIFF
--- a/tools/chibi-run
+++ b/tools/chibi-run
@@ -1,1 +1,3 @@
-LD_LIBRARY_PATH=.: DYLD_LIBRARY_PATH=.: CHIBI_MODULE_PATH=lib ./chibi-scheme "$@"
+#!/bin/sh
+DIR="$(dirname "$0")/.."
+LD_LIBRARY_PATH="$DIR": DYLD_LIBRARY_PATH="$DIR": CHIBI_MODULE_PATH="$DIR"/lib "$DIR"/chibi-scheme "$@"


### PR DESCRIPTION
chibi-run script assumes $(PWD) is at topdir. Let's remove that
assumption so that the script can be used anywhere to launch chibi from
dev environment.