### PR TITLE
Add Tangerine library names

### DIFF
--- a/lib/scheme/bitwise.sld
+++ b/lib/scheme/bitwise.sld
@@ -1,0 +1,22 @@
+
+(define-library (scheme bitwise)
+  (import (srfi 151))
+  (export bitwise-not
+          bitwise-and   bitwise-ior 
+          bitwise-xor   bitwise-eqv
+          bitwise-nand  bitwise-nor 
+          bitwise-andc1 bitwise-andc2
+          bitwise-orc1  bitwise-orc2 
+          arithmetic-shift bit-count integer-length
+          bitwise-if
+          bit-set? any-bit-set? every-bit-set?
+          first-set-bit
+          bit-field bit-field-any? bit-field-every?
+          bit-field-clear bit-field-set
+          bit-field-replace bit-field-replace-same
+          bit-field-rotate bit-field-reverse
+          copy-bit bits->list list->bits
+          bits->vector vector->bits
+          bits bit-swap
+          bitwise-fold bitwise-for-each bitwise-unfold
+          make-bitwise-generator))

--- a/lib/scheme/flonum.sld
+++ b/lib/scheme/flonum.sld
@@ -1,0 +1,32 @@
+(define-library (scheme flonum)
+  (import (srfi 144))
+  (export
+   fl-e fl-e-2 fl-log2-e fl-log10-e fl-log-2 fl-log-10 fl-pi
+   fl-1/pi fl-2/pi fl-pi/2 fl-pi/4 fl-sqrt-pi fl-2/sqrt-pi
+   fl-sqrt-2 fl-sqrt-3 fl-sqrt-5 fl-sqrt-10 fl-1/sqrt-2
+   fl-cbrt-2 fl-cbrt-3 fl-4thrt-2 fl-phi fl-log-phi fl-1/log-phi
+   fl-euler fl-e-euler fl-sin-1 fl-cos-1 fl-greatest fl-least
+   fl-integer-exponent-zero fl-integer-exponent-nan fl-fast-+*
+
+   flonum flonum? fl= fl< fl> fl<= fl>= flodd? fleven?
+   flunordered? flinteger? flzero? flpositive? flnegative?
+
+   fl+ fl- fl* fl/ fl+* flmax flmin flabsdiff
+   flnumerator fldenominator
+
+   fladjacent flcopysign flsgn make-flonum flinteger-fraction
+   flexponent flinteger-exponent flnormalized-fraction-exponent
+   sign-bit flfinite? flinfinite? flnan? flnormalized? fldenormalized?
+   flabs flposdiff flfloor flceiling flround fltruncate
+
+   flexp flexp2 flexp-1 flsquare flsqrt flcbrt flhypot flexpt fllog fllog1+
+   fllog2 fllog10 flsin flcos fltan flasin flacos flatan
+   flsinh flcosh fltanh flasinh flacosh flatanh flremquo
+   flgamma flloggamma flfirst-bessel flsecond-bessel flerf flerfc
+
+   flfloor/ flfloor-quotient flfloor-remainder
+   flceiling/ flceiling-quotient flceiling-remainder
+   fltruncate/ fltruncate-quotient fltruncate-remainder
+   flround/ flround-quotient flround-remainder
+   fleuclidean/ fleuclidean-quotient fleuclidean-remainder
+   flbalanced/ flbalanced-quotient flbalanced-remainder))

--- a/lib/scheme/regex.sld
+++ b/lib/scheme/regex.sld
@@ -1,0 +1,9 @@
+(define-library (scheme regex)
+  (import (srfi 115))
+  (export regexp regexp? valid-sre? rx regexp->sre char-set->sre
+          regexp-matches regexp-matches? regexp-search
+          regexp-replace regexp-replace-all regexp-match->list
+          regexp-fold regexp-extract regexp-split regexp-partition
+          regexp-match? regexp-match-count
+          regexp-match-submatch
+          regexp-match-submatch-start regexp-match-submatch-end))

--- a/lib/scheme/show.sld
+++ b/lib/scheme/show.sld
@@ -1,0 +1,25 @@
+
+(define-library (scheme show)
+  (import (srfi 159))
+  (export
+   ;; base
+   show fn forked with with! each each-in-list call-with-output
+   displayed written written-simply pretty pretty-simply
+   numeric numeric/comma numeric/si numeric/fitted
+   nothing nl fl space-to tab-to escaped maybe-escaped
+   padded padded/right padded/both
+   trimmed trimmed/right trimmed/both trimmed/lazy
+   fitted fitted/right fitted/both
+   joined joined/prefix joined/suffix joined/last joined/dot joined/range
+   ;; columnar
+   call-with-output-generator call-with-output-generators
+   string->line-generator
+   tabular columnar show-columns wrapped wrapped/list wrapped/char
+   justified line-numbers from-file
+   ;; unicode
+   as-unicode unicode-terminal-width
+   ;; color
+   as-red as-blue as-green as-cyan as-yellow
+   as-magenta as-white as-black
+   as-bold as-underline
+   ))


### PR DESCRIPTION
Chibi supports quite a few SRFIs that have been part of Tangerine
edition. These .sld are the same as their srfi counterpart, except the
rename.