### PR TITLE
Implement SRFI 193: Command lines

### DIFF
--- a/lib/srfi/193.sld
+++ b/lib/srfi/193.sld
@@ -1,0 +1,23 @@
+
+(define-library (srfi 193)
+  (export command-line command-name command-args script-file script-directory)
+  (import (scheme base) (chibi filesystem) (chibi pathname)
+          (only (meta) command-line raw-script-file))
+  (begin
+
+    (define (command-name)
+      (let ((filename (car (command-line))))
+        (and (not (= 0 (string-length filename)))
+             (path-strip-extension (path-strip-directory filename)))))
+
+    (define (command-args)
+      (cdr (command-line)))
+
+    (define (script-file)
+      (and raw-script-file
+           (path-normalize
+            (path-resolve raw-script-file (current-directory)))))
+
+    (define (script-directory)
+      (let ((filename (script-file)))
+        (and filename (string-append (path-directory filename) "/"))))))

--- a/tests/srfi-193-test.scm
+++ b/tests/srfi-193-test.scm
@@ -1,0 +1,13 @@
+#! /usr/bin/env chibi-scheme
+
+(import (scheme base) (scheme write) (srfi 193))
+
+(define-syntax pp
+  (syntax-rules ()
+    ((_ expr) (begin (write 'expr) (display " => ") (write expr) (newline)))))
+
+(pp (command-line))
+(pp (command-name))
+(pp (command-args))
+(pp (script-file))
+(pp (script-directory))


### PR DESCRIPTION
RnRS gives us a `command-line` procedure to get command line arguments. Since that procedure's specification is vague, I drafted a SRFI that specifies it in detail and adds some new related procedures. I'll submit the draft to the SRFI process once it's cleaned up.

Anyway, here's a Chibi implementation. It's simple, but needs to save the full `argv` from `run_main` into a Scheme variable so a few C additions are required. Would you like to include this kind of functionality in Chibi, and is the current implementation strategy reasonable?

Here's some sample output from the included `command-lines-test` script:

```scheme
(os-executable-file) => #f
(os-command-line) => ("chibi-scheme" "./command-lines-test" "foo" "bar")
(script-file) => "/Users/lassi/tmp/scheme/chibi/command-lines-test"
(script-directory) => "/Users/lassi/tmp/scheme/chibi/"
(command-name) => "command-lines-test"
(command-args) => ("foo" "bar")
(command-line) => ("command-lines-test" "foo" "bar")
(command-line-offset) => 1
``` 