### PR TITLE
(chibi net): add address-info-canonname

### DIFF
--- a/lib/chibi/net.sld
+++ b/lib/chibi/net.sld
@@ -8,7 +8,7 @@
           send/non-blocking receive!/non-blocking receive/non-blocking
           address-info-family address-info-socket-type address-info-protocol
           address-info-flags address-info-address address-info-address-length
-          address-info-next
+          address-info-canonname address-info-next
           address-family/unix address-family/inet address-family/inet6
           address-family/unspecified
           socket-type/stream socket-type/datagram socket-type/raw

--- a/lib/chibi/net.stub
+++ b/lib/chibi/net.stub
@@ -21,6 +21,7 @@
   (int              ai_flags     address-info-flags)
   ((link sockaddr)  ai_addr      address-info-address)
   (size_t           ai_addrlen   address-info-address-length)
+  (string           ai_canonname address-info-canonname)
   ((link addrinfo)  ai_next      address-info-next))
 
 ;;> The addrinfo struct accessors.


### PR DESCRIPTION
`ai/canonname` has already been available in `(chibi net)` to request the canonical name of a host, but there wasn't a way to actually access it.  This PR exposes the `struct addrinfo` field `ai_canonname` via the getter `address-info-canonname`.

I chose the name `address-info-canonname` instead of something like `address-info-canonical-name` to match the name of `ai/canonname`.  I think their names should be consistent since they go together.