### PR TITLE
make-promise: return the argument if it's already a promise

### DIFF
--- a/lib/scheme/lazy.sld
+++ b/lib/scheme/lazy.sld
@@ -4,4 +4,6 @@
   (export delay force delay-force make-promise promise?)
   (begin
     (define (make-promise x)
-      (delay x))))
+      (if (promise? x)
+          x
+          (delay x)))))

--- a/tests/r7rs-tests.scm
+++ b/tests/r7rs-tests.scm
@@ -325,6 +325,9 @@
     (let ((x (make-promise (+ 2 2))))
       (force x)
       (promise? x)))
+(test #t
+    (let ((x (make-promise (+ 2 2))))
+      (eqv? x (make-promise x))))
 
 (define radix
   (make-parameter


### PR DESCRIPTION
Chibi has not been conforming to R7RS here: `make-promise` needs to simply return its argument if it's already a promise instead of wrapping it again.

Chibi:
```
> (define foo (make-promise 1))
> (define bar (make-promise foo))
> (eqv? foo bar)
#f
> (force bar)
((#f . #<procedure #f>) promise)
> (force (force bar))
1
```

Chicken:
```
#;1> (define foo (make-promise 1))
#;2> (define bar (make-promise foo))
#;3> (eqv? foo bar)
#t
#;4> (force bar)
1
```

Kawa:
```
#|kawa:1|# (define foo (make-promise 1))
#|kawa:2|# (define bar (make-promise foo))
#|kawa:3|# (eqv? foo bar)
#t
#|kawa:4|# (force bar)
1
```