### PR TITLE
Fix SRFI 133 vector-every crash on empty vector

### DIFF
--- a/lib/srfi/133/vector.scm
+++ b/lib/srfi/133/vector.scm
@@ -163,12 +163,13 @@
 
 (define (vector-every pred? vec1 . o)
   (let ((len (apply min (vector-length vec1) (map vector-length o))))
-    (let lp ((i 0))
-      (let ((x (apply pred? (vector-ref vec1 i)
-                      (map (lambda (v) (vector-ref v i)) o))))
-        (if (= i (- len 1))
-            x
-            (and x (lp (+ i 1))))))))
+    (or (zero? len)
+        (let lp ((i 0))
+          (let ((x (apply pred? (vector-ref vec1 i)
+                          (map (lambda (v) (vector-ref v i)) o))))
+            (if (= i (- len 1))
+                x
+                (and x (lp (+ i 1)))))))))
 
 (define (vector-swap! vec i j)
   (let ((tmp (vector-ref vec i)))


### PR DESCRIPTION
`vector-every` crashes when called on an empty vector, because it always calls `(vector-ref vec1 0)` on its second argument regardless of size. Adding an `or` guard to the function fixes this bug.