### PR TITLE
Fix build with emscripten to run chibi in the browser.

### DIFF
--- a/include/chibi/sexp-hufftabdefs.h
+++ b/include/chibi/sexp-hufftabdefs.h
@@ -1,5 +1,5 @@
 
-char _huff_tab1[8], _huff_tab2[8], _huff_tab3[2], _huff_tab4[2],
+extern char _huff_tab1[8], _huff_tab2[8], _huff_tab3[2], _huff_tab4[2],
   _huff_tab5[4], _huff_tab6[2], _huff_tab7[4], _huff_tab8[4],
   _huff_tab9[4], _huff_tab10[4], _huff_tab11[4], _huff_tab12[2],
   _huff_tab13[8], _huff_tab14[2], _huff_tab15[8], _huff_tab16[8],


### PR DESCRIPTION
emcc (Emscripten gcc/clang-like replacement) 1.39.16 (9ecd579ac647c4484e2d9af2ab0bbc1e1505aa95)

Thanks @pmp-p.