### PR TITLE
Unparse json feature

### DIFF
--- a/lib/chibi/json-test.sld
+++ b/lib/chibi/json-test.sld
@@ -4,7 +4,7 @@
   (export run-tests)
   (begin
     (define (run-tests)
-      (test-begin "json")
+      (test-begin "json-parse")
       (test 1 (parse-json "1"))
       (test 1.5 (parse-json "1.5"))
       (test 1000.0 (parse-json "1e3"))
@@ -67,4 +67,37 @@
     ]
   }
 }}"))
+      (test-end)
+      (test-begin "json-unparse")
+      (test "1" (unparse-json 1))
+      (test "1.5" (unparse-json 1.5))
+      (test "1000" (unparse-json 1E3))
+      (test  "\"\\u00E1\"" (unparse-json "á"))
+      (test  "\"\\uD801\\uDC37\"" (unparse-json "𐐷"))
+      (test  "\"\\uD83D\\uDE10\"" (unparse-json "😐"))
+      (test "{\"menu\":{\"id\":\"file\",\"value\":\"File\",\"popup\":{\"menuitem\":[{\"value\":\"New\",\"onclick\":\"CreateNewDoc()\"},{\"value\":\"Open\",\"onclick\":\"OpenDoc()\"},{\"value\":\"Close\",\"onclick\":\"CloseDoc()\"}]}}}"
+       (unparse-json '((menu
+                        (id . "file")
+                        (value . "File")
+                        (popup
+                         (menuitem
+                          . #(((value . "New") (onclick . "CreateNewDoc()"))
+                              ((value . "Open") (onclick . "OpenDoc()"))
+                              ((value . "Close") (onclick . "CloseDoc()")))))))))
+      (test "{\"glossary\":{\"title\":\"example glossary\",\"GlossDiv\":{\"title\":\"S\",\"GlossList\":{\"GlossEntry\":{\"ID\":\"SGML\",\"SortAs\":\"SGML\",\"GlossTerm\":\"Standard Generalized Markup Language\",\"Acronym\":\"SGML\",\"Abbrev\":\"ISO 8879:1986\",\"GlossDef\":{\"para\":\"A meta-markup language, used to create markup languages such as DocBook.\",\"GlossSeeAlso\":[\"GML\",\"XML\"]},\"GlossSee\":\"markup\"}}}}}"
+       (unparse-json '((glossary
+               (title . "example glossary")
+               (GlossDiv
+                (title . "S")
+                (GlossList
+                 (GlossEntry
+                  (ID . "SGML")
+                  (SortAs . "SGML")
+                  (GlossTerm . "Standard Generalized Markup Language")
+                  (Acronym . "SGML")
+                  (Abbrev . "ISO 8879:1986")
+                  (GlossDef
+                   (para . "A meta-markup language, used to create markup languages such as DocBook.")
+                   (GlossSeeAlso . #("GML" "XML")))
+                  (GlossSee . "markup"))))))))
       (test-end))))

--- a/lib/chibi/json.c
+++ b/lib/chibi/json.c
@@ -326,7 +326,7 @@ sexp unparse_json (sexp ctx, sexp self, sexp obj);
 sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
-  res = SEXP_NULL;
+  res = SEXP_VOID;
   int sign = 1;
   long num = sexp_unbox_fixnum(obj);
   char digit;
@@ -360,7 +360,7 @@ sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj) {
 sexp unparse_json_flonum(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
-  res = SEXP_NULL;
+  res = SEXP_VOID;
   char cout[FLONUM_SIGNIFICANT_DIGITS + FLONUM_EXP_MAX_DIGITS + 5];
     // Extra space for signs (x2), dot, E and \0
 
@@ -380,7 +380,7 @@ sexp unparse_json_flonum(sexp ctx, sexp self, const sexp obj) {
 sexp unparse_json_string(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
-  res = SEXP_NULL;
+  res = SEXP_VOID;
 
   tmp = sexp_c_string(ctx, "\"", -1);
   res = sexp_cons(ctx, tmp, res);
@@ -448,7 +448,7 @@ sexp unparse_json_string(sexp ctx, sexp self, const sexp obj) {
 sexp unparse_json_array(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
-  res = SEXP_NULL;
+  res = SEXP_VOID;
 
   tmp = sexp_c_string(ctx, "[", -1);
   res = sexp_cons(ctx, tmp, res);
@@ -482,7 +482,7 @@ sexp unparse_json_array(sexp ctx, sexp self, const sexp obj) {
 sexp unparse_json_object(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var6(res, tmp, it, cur, key, val);
   sexp_gc_preserve6(ctx, res, tmp, it, cur, key, val);
-  res = SEXP_NULL;
+  res = SEXP_VOID;
 
   tmp = sexp_c_string(ctx, "{", -1);
   res = sexp_cons(ctx, tmp, res);
@@ -538,7 +538,7 @@ except:
 sexp unparse_json (sexp ctx, sexp self, sexp obj) {
   sexp_gc_var1(res);
   sexp_gc_preserve1(ctx, res);
-  res = SEXP_NULL;
+  res = SEXP_VOID;
 
   if( sexp_symbolp(obj) ) {
     obj = sexp_symbol_to_string(ctx, obj);

--- a/lib/chibi/json.c
+++ b/lib/chibi/json.c
@@ -323,7 +323,7 @@ sexp sexp_parse_json (sexp ctx, sexp self, sexp_sint_t n, sexp str) {
 sexp unparse_json (sexp ctx, sexp self, sexp obj);
 
 
-sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj){
+sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
   res = SEXP_NULL;
@@ -336,7 +336,7 @@ sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj){
 }
 
 
-sexp unparse_json_string(sexp ctx, sexp self, const sexp obj){
+sexp unparse_json_string(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
   res = SEXP_NULL;
@@ -348,10 +348,10 @@ sexp unparse_json_string(sexp ctx, sexp self, const sexp obj){
   unsigned long ch, chh, chl;
 
   sexp_uint_t len = sexp_string_length(obj);
-  for(sexp_uint_t i=0; i!= len; i++){
+  for(sexp_uint_t i=0; i!= len; i++) {
     ch = sexp_unbox_character(sexp_string_ref(ctx, obj, sexp_make_fixnum(i)));
-    if(ch < 0x7F){
-      switch(ch){
+    if(ch < 0x7F) {
+      switch(ch) {
         case '\\':
           sprintf(cout, "\\\\");
           break;
@@ -377,13 +377,13 @@ sexp unparse_json_string(sexp ctx, sexp self, const sexp obj){
           sprintf(cout, "%c", ch);
           break;
       }
-    } else if(ch <= 0xFFFF){
+    } else if(ch <= 0xFFFF) {
       sprintf(cout,"\\u%04lX", ch);
     } else {
       // Surrogate pair
       chh = (0xD800 - (0x10000 >> 10) + ((ch) >> 10));
       chl = (0xDC00 + ((ch) & 0x3FF));
-      if (chh > 0xFFFF || chl > 0xFFFF){
+      if (chh > 0xFFFF || chl > 0xFFFF) {
         res = sexp_json_unparse_exception(ctx, self, "unable to encode string", obj);
         sexp_gc_release2(ctx);
         return res;
@@ -404,7 +404,7 @@ sexp unparse_json_string(sexp ctx, sexp self, const sexp obj){
   return res;
 }
 
-sexp unparse_json_array(sexp ctx, sexp self, const sexp obj){
+sexp unparse_json_array(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
   res = SEXP_NULL;
@@ -413,15 +413,15 @@ sexp unparse_json_array(sexp ctx, sexp self, const sexp obj){
   res = sexp_cons(ctx, tmp, res);
 
   int len = sexp_vector_length(obj);
-  for (int i=0; i!=len; i++){
+  for (int i=0; i!=len; i++) {
     tmp = unparse_json(ctx, self, sexp_vector_ref(obj, sexp_make_fixnum(i)));
-    if (sexp_exceptionp(tmp)){
+    if (sexp_exceptionp(tmp)) {
       sexp_gc_release2(ctx);
       return tmp;
     }
     res = sexp_cons(ctx, tmp, res);
 
-    if (i != len-1){
+    if (i != len-1) {
       tmp = sexp_c_string(ctx, ",", -1);
       res = sexp_cons(ctx, tmp, res);
     }
@@ -438,7 +438,7 @@ sexp unparse_json_array(sexp ctx, sexp self, const sexp obj){
 }
 
 
-sexp unparse_json_object(sexp ctx, sexp self, const sexp obj){
+sexp unparse_json_object(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var6(res, tmp, it, cur, key, val);
   sexp_gc_preserve6(ctx, res, tmp, it, cur, key, val);
   res = SEXP_NULL;
@@ -448,21 +448,21 @@ sexp unparse_json_object(sexp ctx, sexp self, const sexp obj){
 
   int len = sexp_unbox_fixnum(sexp_length(ctx, obj));
   it = obj;
-  for (int i=0; i!=len; i++){
+  for (int i=0; i!=len; i++) {
     cur = sexp_car(it);
-    if (!sexp_pairp(cur)){
+    if (!sexp_pairp(cur)) {
       res = sexp_json_unparse_exception(ctx, self, "unable to encode key-value pair: not a pair", obj);
       goto except;
     }
 
     // Key
     key = sexp_car(cur);
-    if (!(sexp_symbolp(key) /*|| sexp_stringp(key)*/)){
+    if (!(sexp_symbolp(key) /*|| sexp_stringp(key)*/)) {
       res = sexp_json_unparse_exception(ctx, self, "unable to encode key: not a symbol", key);
       goto except;
     }
     tmp = unparse_json(ctx, self, key);
-    if (sexp_exceptionp(tmp)){
+    if (sexp_exceptionp(tmp)) {
       res = tmp;
       goto except;
     }
@@ -477,7 +477,7 @@ sexp unparse_json_object(sexp ctx, sexp self, const sexp obj){
     tmp = unparse_json(ctx, self, val);
     res = sexp_cons(ctx, tmp, res);
 
-    if (i != len-1){
+    if (i != len-1) {
       tmp = sexp_c_string(ctx, ",", -1);
       res = sexp_cons(ctx, tmp, res);
     }
@@ -494,33 +494,27 @@ except:
   return res;
 }
 
-sexp unparse_json (sexp ctx, sexp self, sexp obj){
+sexp unparse_json (sexp ctx, sexp self, sexp obj) {
   sexp_gc_var1(res);
   sexp_gc_preserve1(ctx, res);
   res = SEXP_NULL;
 
-  if( sexp_symbolp(obj) ){
-    // SYMBOL
-    obj =  sexp_symbol_to_string(ctx, obj);
+  if( sexp_symbolp(obj) ) {
+    obj = sexp_symbol_to_string(ctx, obj);
     res = unparse_json_string(ctx, self, obj);
-  } else if (sexp_stringp(obj)){
-    // STRING
+  } else if (sexp_stringp(obj)) {
     res = unparse_json_string(ctx, self, obj);
-  } else if (sexp_listp(ctx, obj) == SEXP_TRUE){
-    // OBJECT
+  } else if (sexp_listp(ctx, obj) == SEXP_TRUE) {
     res = unparse_json_object(ctx, self, obj);
-  } else if (sexp_vectorp(obj)){
-    // ARRAY
+  } else if (sexp_vectorp(obj)) {
     res = unparse_json_array(ctx, self, obj);
-  } else if(sexp_fixnump(obj)){
+  } else if(sexp_fixnump(obj)) {
     res = unparse_json_fixnum(ctx, self, obj);
-  } else if (sexp_numberp(obj)){
-    // FLONUM or RATIONAL
-  } else if (obj == SEXP_FALSE){
+  } else if (obj == SEXP_FALSE) {
     res = sexp_c_string(ctx, "false", -1);
-  } else if (obj == SEXP_TRUE){
+  } else if (obj == SEXP_TRUE) {
     res = sexp_c_string(ctx, "true", -1);
-  } else if (obj == SEXP_NULL){
+  } else if (obj == SEXP_NULL) {
     res = sexp_c_string(ctx, "null", -1);
   } else {
     res = sexp_json_unparse_exception(ctx, self, "unable to encode element", obj);

--- a/lib/chibi/json.c
+++ b/lib/chibi/json.c
@@ -1,6 +1,7 @@
-/*  json.c -- fast json parser                           */
-/*  Copyright (c) 2019 Alex Shinn.  All rights reserved. */
-/*  BSD-style license: http://synthcode.com/license.txt  */
+/*  json.c -- fast json parser and unparser                  */
+/*  Copyright (c) 2019 Alex Shinn.      All rights reserved. */
+/*  Copyright (c) 2020 Ekaitz Zarraga.  All rights reserved. */
+/*  BSD-style license: http://synthcode.com/license.txt      */
 
 #include <chibi/eval.h>
 

--- a/lib/chibi/json.c
+++ b/lib/chibi/json.c
@@ -336,6 +336,28 @@ sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj) {
 }
 
 
+#define FLONUM_SIGNIFICANT_DIGITS 10
+#define FLONUM_EXP_MAX_DIGITS 3
+sexp unparse_json_flonum(sexp ctx, sexp self, const sexp obj) {
+  sexp_gc_var2(res, tmp);
+  sexp_gc_preserve2(ctx, res, tmp);
+  res = SEXP_NULL;
+  char cout[FLONUM_SIGNIFICANT_DIGITS + FLONUM_EXP_MAX_DIGITS + 5];
+    // Extra space for signs (x2), dot, E and \0
+
+  if (sexp_infp(obj) || sexp_nanp(obj)) {
+    res = sexp_json_unparse_exception(ctx, self, "unable to encode number", obj);
+    sexp_gc_release2(ctx);
+    return res;
+  }
+
+  sprintf(cout, "%.*G", FLONUM_SIGNIFICANT_DIGITS, sexp_flonum_value(obj));
+  res = sexp_c_string(ctx, cout, -1);
+  sexp_gc_release2(ctx);
+  return res;
+}
+
+
 sexp unparse_json_string(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
@@ -510,6 +532,8 @@ sexp unparse_json (sexp ctx, sexp self, sexp obj) {
     res = unparse_json_array(ctx, self, obj);
   } else if(sexp_fixnump(obj)) {
     res = unparse_json_fixnum(ctx, self, obj);
+  } else if (sexp_flonump(obj)) {
+    res = unparse_json_flonum(ctx, self, obj); // OTHER TYPES? bignum etc?
   } else if (obj == SEXP_FALSE) {
     res = sexp_c_string(ctx, "false", -1);
   } else if (obj == SEXP_TRUE) {

--- a/lib/chibi/json.c
+++ b/lib/chibi/json.c
@@ -327,10 +327,29 @@ sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj) {
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
   res = SEXP_NULL;
+  int sign = 1;
   long num = sexp_unbox_fixnum(obj);
-  char* buff = alloca( num==0 ? 2 : (log10(abs(num))+3) );
-  sprintf(buff, "%ld", num);
-  res = sexp_c_string(ctx, buff, -1);
+  char digit;
+  if (num == 0) {
+    res = sexp_c_string(ctx, "0", -1);
+  } else {
+    if (num < 0) {
+      sign = -1;
+      num = labs(num);
+    }
+    while (num > 0) {
+      digit = '0' + num%10;
+      num /= 10;
+
+      tmp = sexp_c_string(ctx, &digit, 1);
+      res = sexp_cons(ctx, tmp, res);
+    }
+    if (sign==-1) {
+      tmp = sexp_c_string(ctx, "-", -1);
+      res = sexp_cons(ctx, tmp, res);
+    }
+    res = sexp_string_concatenate(ctx, res, SEXP_FALSE);
+  }
   sexp_gc_release2(ctx);
   return res;
 }

--- a/lib/chibi/json.c
+++ b/lib/chibi/json.c
@@ -516,6 +516,8 @@ sexp unparse_json (sexp ctx, sexp self, sexp obj) {
     res = sexp_c_string(ctx, "true", -1);
   } else if (obj == SEXP_NULL) {
     res = sexp_c_string(ctx, "null", -1);
+  } else if (sexp_pairp(obj)) {
+    res = sexp_json_unparse_exception(ctx, self, "unable to encode elemente: key-value pair out of object", obj);
   } else {
     res = sexp_json_unparse_exception(ctx, self, "unable to encode element", obj);
   }

--- a/lib/chibi/json.c
+++ b/lib/chibi/json.c
@@ -314,6 +314,19 @@ sexp sexp_parse_json (sexp ctx, sexp self, sexp_sint_t n, sexp str) {
 sexp unparse_json (sexp ctx, sexp self, sexp obj);
 
 
+sexp unparse_json_fixnum(sexp ctx, sexp self, const sexp obj){
+  sexp_gc_var2(res, tmp);
+  sexp_gc_preserve2(ctx, res, tmp);
+  res = SEXP_NULL;
+  long num = sexp_unbox_fixnum(obj);
+  char* buff = alloca( num==0 ? 2 : (log10(abs(num))+3) );
+  sprintf(buff, "%ld", num);
+  res = sexp_c_string(ctx, buff, -1);
+  sexp_gc_release2(ctx);
+  return res;
+}
+
+
 sexp unparse_json_string(sexp ctx, sexp self, const sexp obj){
   sexp_gc_var2(res, tmp);
   sexp_gc_preserve2(ctx, res, tmp);
@@ -495,8 +508,8 @@ sexp unparse_json (sexp ctx, sexp self, sexp obj){
   } else if (sexp_vectorp(obj)){
     // ARRAY
     res = unparse_json_array(ctx, self, obj);
-  } else if(sexp_integerp(obj)){
-    // FIXNUM NUMBER
+  } else if(sexp_fixnump(obj)){
+    res = unparse_json_fixnum(ctx, self, obj);
   } else if (sexp_numberp(obj)){
     // FLONUM or RATIONAL
   } else if (obj == SEXP_FALSE){

--- a/lib/chibi/json.sld
+++ b/lib/chibi/json.sld
@@ -2,4 +2,5 @@
 (define-library (chibi json)
   (import (scheme base))
   (export parse-json)
+  (export unparse-json)
   (include-shared "json"))


### PR DESCRIPTION
I made a JSON encoder functionality called `unparse-json` in order to solve #590 .
It's supposed to be the counterpart of `parse-json`, using the same types.

I'm not sure if the implementation is best in many cases. It's probably easy to improve in many points, that's why I separated everything in self-contained commits that are easier to review.

There are also some things I'm not sure about:

- JSON doesn't really limit the size of the numbers you can store on it, so I'm not sure if it's reasonable to add support for Bignums. Maybe we can convert them to float?
- I didn't add support for rationals in order to make the precision loss during the float conversion explicit and force the user to remind that JSON doesn't support them automatically.
- There are two implementations of the fixnum encoder, one uses alloca (bb1fdbb) and the other  (3745c16) doesn't but it's uglier in my opinion.
- Not sure about flonum implementation neither. You probably come up with something better.
- Portability is also a concern.

So it's a working solution but we'll probably need to make some changes.

I hope it's useful.

Thanks