### PR TITLE
Win32: Guess SEXP_USE_GREEN_THREADS

### DIFF
--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -366,7 +366,11 @@
 #endif
 
 #ifndef SEXP_USE_GREEN_THREADS
+#if defined(_WIN32)
+#define SEXP_USE_GREEN_THREADS 0
+#else
 #define SEXP_USE_GREEN_THREADS ! SEXP_USE_NO_FEATURES
+#endif
 #endif
 
 #ifndef SEXP_USE_DEBUG_THREADS


### PR DESCRIPTION
Guess SEXP_USE_GREEN_THREADS=0 ifdef `_WIN32`, to prevent #614 or #645 .