### PR TITLE
Check the number of args to delay and delay-force

### DIFF
--- a/lib/init-7.scm
+++ b/lib/init-7.scm
@@ -360,11 +360,15 @@
 (define-syntax delay-force
   (er-macro-transformer
    (lambda (expr rename compare)
+     (if (null? (cdr expr)) (error "not enough args" expr))
+     (if (not (null? (cddr expr))) (error "too many args" expr))
      `(,(rename 'promise) #f (,(rename 'lambda) () ,(cadr expr))))))
 
 (define-syntax delay
   (er-macro-transformer
    (lambda (expr rename compare)
+     (if (null? (cdr expr)) (error "not enough args" expr))
+     (if (not (null? (cddr expr))) (error "too many args" expr))
      `(,(rename 'delay-force) (,(rename 'promise) #t ,(cadr expr))))))
 
 (define-syntax define-auxiliary-syntax


### PR DESCRIPTION
These take exactly one expression, but passing nothing has been giving an error about `()` not being a pair and passing too much has been giving the potentially confusing behavior where args are "ignored" without complaint.

I stumbled across this before by accidentally doing

`(delay foo bar ...)`

when I meant

`(delay (begin foo bar ...))`