### PR TITLE
snow: accept "_" as version separator

### DIFF
--- a/lib/chibi/snow/utils.scm
+++ b/lib/chibi/snow/utils.scm
@@ -57,7 +57,7 @@
 (define (version-split str)
   (if str
       (map (lambda (x) (or (string->number x) x))
-        (string-split str #\.))
+        (string-split str (string->char-set "._")))
       '()))
 
 (define (version-compare a b)

--- a/lib/chibi/snow/utils.sld
+++ b/lib/chibi/snow/utils.sld
@@ -11,6 +11,7 @@
           (scheme write)
           (scheme process-context)
           (srfi 1)
+          (chibi char-set)
           (chibi net http)
           (chibi pathname)
           (chibi string)


### PR DESCRIPTION
    $ tools/snow-chibi  implementations
    WARNING: Implementation gauche is an unsupported version,
    0.9.10_pre1, but at least 0.9.4 is required.
    cyclone
    sagittarius

The easy solution is also accept "_" as version separator and consider
"pre1" the forth component. This makes the warning go away, and I don't
think it'll affect version comparison on other schemes.