### PR TITLE
Initialize fileno count in sexp_make_fileno_op()

### DIFF
--- a/sexp.c
+++ b/sexp.c
@@ -1865,6 +1865,7 @@ sexp sexp_make_fileno_op (sexp ctx, sexp self, sexp_sint_t n, sexp fd, sexp no_c
   if (sexp_filenop(res)) {
     sexp_fileno_no_closep(res) = sexp_truep(no_closep);
     sexp_fileno_openp(res) = 1;  /* not necessarily */
+    sexp_fileno_count(res) = 0;
     return res;
   }
 #endif
@@ -1873,6 +1874,7 @@ sexp sexp_make_fileno_op (sexp ctx, sexp self, sexp_sint_t n, sexp fd, sexp no_c
   if (!sexp_exceptionp(res)) {
     sexp_fileno_fd(res) = sexp_unbox_fixnum(fd);
     sexp_fileno_openp(res) = 1;
+    sexp_fileno_count(res) = 0;
     sexp_fileno_no_closep(res) = sexp_truep(no_closep);
 #if SEXP_USE_WEAK_REFERENCES
     sexp_insert_fileno(ctx, res);


### PR DESCRIPTION
I'm hunting down some weird problem where (process->sexp) hangs. It is
because the pipe to the child's stdin is not closed properly, so the
child process never receives eof to terminate itself.

Sprinkling fprintf() further, it's found that the sexp_finalize_fileno()
inside sexp_finalize_port() is not called because the original fileno
count is zero, so after decrement it's negative one. Negative one is not
zero, so no closing.

This looks obviously bad. The fileno count sometimes is wrong right
after this line

    sexp_fileno_count(fileno)++;

in sexp_open_input_file_descriptor(). It's zero instead of one, meaning
it was negative one before. Bad bad bad. I don't think negative counts
are intentional.

From the look of it (and I'm very new to Chibi) it looks like we may
need to initialize fileno count in open-pipe function. And fileno sexp
is allocated in this function. This works for me (the bug is reliably
reproducible, so reliably verified) but I don't know if this is really
the right place...