### PR TITLE
Small documentation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ MODULE_DOCS := app ast base64 bytevector config crypto/md5 crypto/rsa \
 	crypto/sha2 diff disasm doc edit-distance equiv filesystem generic \
 	heap-stats io iset/base iset/constructors iset/iterators json loop \
 	match math/prime memoize mime modules net net/http-server net/servlet \
-	parse pathname process repl scribble string stty sxml system temp-file \
-	test time trace type-inference uri weak monad/environment crypto/sha2
+	optional parse pathname process repl scribble string stty sxml system \
+	temp-file test time trace type-inference uri weak monad/environment \
+	crypto/sha2
 
 IMAGE_FILES = lib/chibi.img lib/red.img lib/snow.img
 

--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -1343,6 +1343,8 @@ namespace.
 
 \item{\hyperlink["lib/chibi/net/servlet.html"]{(chibi net servlet) - HTTP servlets for http-server or CGI}}
 
+\item{\hyperlink["lib/chibi/optional.html"]{(chibi optional) - Syntax to support optional and named keyword arguments}}
+
 \item{\hyperlink["lib/chibi/parse.html"]{(chibi parse) - Parser combinators with convenient syntax}}
 
 \item{\hyperlink["lib/chibi/pathname.html"]{(chibi pathname) - Utilities to decompose and manipulate pathnames}}

--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -1272,7 +1272,7 @@ snow-fort):
 \item{\hyperlink["http://srfi.schemers.org/srfi-160/srfi-160.html"]{(srfi 160) - homogeneous numeric vector libraries}}
 \item{\hyperlink["http://srfi.schemers.org/srfi-165/srfi-165.html"]{(srfi 165) - the environment Monad}}
 \item{\hyperlink["http://srfi.schemers.org/srfi-166/srfi-166.html"]{(srfi 166) - monadic formatting}}
-\item{\hyperlink["http://srfi.schemers.org/srfi-166/srfi-188.html"]{(srfi 188) - splicing binding constructs for syntactic keywords}}
+\item{\hyperlink["http://srfi.schemers.org/srfi-188/srfi-188.html"]{(srfi 188) - splicing binding constructs for syntactic keywords}}
 
 ]
 

--- a/lib/chibi/trace.scm
+++ b/lib/chibi/trace.scm
@@ -34,7 +34,7 @@
         (show-trace-result cell args res)
         res))))
 
-;;> Write a trace of all calls to the procedure \var{proc} to
+;;> Write a trace of all calls to the procedure \var{id} to
 ;;> \scheme{(current-error-port)}.
 
 (define-syntax trace
@@ -42,7 +42,7 @@
     ((trace id)
      (trace-cell (env-cell (interaction-environment) 'id)))))
 
-;;> Remove any active traces on the procedure \var{proc}.
+;;> Remove any active traces on the procedure \var{id}.
 
 (define-syntax untrace
   (syntax-rules ()


### PR DESCRIPTION
These commits add the `(chibi optional)` documentation to the main page, where it was missing. The http link to SRFI 188 is fixed, and the documentation of the `trace` and `untrace` procedures of `(chibi trace)` is updated such that actual parameter names and the documented ones match. Let me know if there is room for improvement and/or whether I should squash these commits into a single one.