### PR TITLE
make optional-test and diff-test run without (chibi test)

### DIFF
--- a/lib/chibi/diff-test.sld
+++ b/lib/chibi/diff-test.sld
@@ -1,10 +1,11 @@
 
 (define-library (chibi diff-test)
-  (import (scheme base) (chibi diff) (chibi test))
+  (import (scheme base) (chibi diff))
   (export run-tests)
   (cond-expand
    (chibi (import (chibi test)))
    (else
+    (import (scheme write))
     ;; inline (chibi test) to avoid circular dependencies in snow
     ;; installations
     (begin

--- a/lib/chibi/optional-test.sld
+++ b/lib/chibi/optional-test.sld
@@ -1,9 +1,10 @@
 
 (define-library (chibi optional-test)
-  (import (scheme base) (chibi optional) (chibi test))
+  (import (scheme base) (chibi optional))
   (cond-expand
    (chibi (import (chibi test)))
    (else
+    (import (scheme write))
     ;; inline (chibi test) to avoid circular dependencies in snow
     ;; installations
     (begin
@@ -52,13 +53,18 @@
       (test '(0 1 (2 3 4))
           (let-optionals '(0 1 2 3 4) ((a 10) (b 11) . c)
             (list a b c)))
-      (test-error '(0 11 12)
-          ((opt-lambda (a (b 11) (c 12))
-             (list a b c))))
+      (cond-expand
+       (gauche)     ; gauche detects this at compile-time, can't catch
+       (else (test-error '(0 11 12)
+                         ((opt-lambda (a (b 11) (c 12))
+                            (list a b c))))))
       (let ()
         (define-opt (f a (b 11) (c 12))
           (list a b c))
-        (test-error (f))
+        (cond-expand
+         (gauche)
+         (else
+          (test-error (f))))
         (test '(0 11 12) (f 0))
         (test '(0 1 12) (f 0 1))
         (test '(0 1 2) (f 0 1 2))


### PR DESCRIPTION
Tested with gauche. It's mostly about not importing (chibi test)
unconditionally, and importing (scheme write). And in one case I need to
exclude some tests because gauche catches invalid call forms at compile
time. I'm not sure if that can be caught...