### PR TITLE
snow: confirm before uploading packages

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -947,9 +947,11 @@
    ((package-file? (car o))
     (if (not (every package-file? (cdr o)))
         (non-homogeneous))
-    (for-each
-     (lambda (package) (upload-package cfg spec package))
-     o))
+    (if (yes-or-no? cfg "Upload " o " to "
+                    (remote-uri cfg '(command package uri) "/?"))
+      (for-each
+       (lambda (package) (upload-package cfg spec package))
+       o)))
    (else
     (if (any package-file? (cdr o))
         (non-homogeneous))
@@ -958,7 +960,9 @@
            (package (create-package (car spec+files)
                                     (cdr spec+files)
                                     package-file)))
-      (upload-package cfg spec package package-file)))))
+      (if (yes-or-no? cfg "Upload " o " to "
+                      (remote-uri cfg '(command package uri) "/?"))
+        (upload-package cfg spec package package-file))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Remove - removes the listed libraries.

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -947,6 +947,7 @@
    ((package-file? (car o))
     (if (not (every package-file? (cdr o)))
         (non-homogeneous))
+    ;; TODO: include a summary (version, file size, etc.)
     (if (yes-or-no? cfg "Upload " o " to "
                     (remote-uri cfg '(command package uri) "/?"))
       (for-each
@@ -960,6 +961,7 @@
            (package (create-package (car spec+files)
                                     (cdr spec+files)
                                     package-file)))
+      ;; TODO: include a summary (version, file size, etc.)
       (if (yes-or-no? cfg "Upload " o " to "
                       (remote-uri cfg '(command package uri) "/?"))
         (upload-package cfg spec package package-file))))))


### PR DESCRIPTION
Uploading a package is an irreversible operation. It's not even about
accidentally leaking your secret sauce to the internet. You could upload
a package to snow-fort.org by accident and pollute the package name
space [1].

So let's ask the user first before going ahead uploading stuff. We only
ask once even if we're going to upload a dozen packages, so it's not
that annoying. The target repo is also shown in case you want to upload
to a custom repo and want to make sure it does so.

[1] I did (while attempting to uploading to a local snow-fort instance
    during testing). I guess `(chibi snow commands)` is forever mine
    now.