### PR TITLE
chibi-scheme.1: document CHIBI_IGNORE_SYSTEM_PATH

### DIFF
--- a/doc/chibi-scheme.1
+++ b/doc/chibi-scheme.1
@@ -243,7 +243,13 @@ searches for modules in directories in the following order:
           directories included with -A path option
 
 If CHIBI_MODULE_PATH is unset, the directories "./lib", and "." are
-search in order.
+searched in order. Set to empty to only consider -I, system
+directories and -A.
+
+.TP
+.B CHIBI_IGNORE_SYSTEM_PATH
+If set to anything but "0", system directories (as listed above) are
+not included in the search paths.
 
 .SH AUTHORS
 .PP


### PR DESCRIPTION
while at there, spell out the empty CHIBI_MODULE_PATH case. It's obvious
if you really think about it, but it's even better if I don't have to
read between the lines.

I did grep getenv to find if anything was missing. There is
CHIBI_MAX_ALLOC, but I think that one is more about debugging
out-of-memory than to be customized by the user.