### PR TITLE
make 9front "work" again by properly handling 64-bit typedefs

### DIFF
--- a/include/chibi/bignum.h
+++ b/include/chibi/bignum.h
@@ -8,7 +8,11 @@
 #include "chibi/eval.h"
 
 #if SEXP_USE_CUSTOM_LONG_LONGS
+#ifdef PLAN9
+#include <ape/stdint.h>
+#else
 #include <stdint.h>
+#endif
 typedef struct
 {
   uint64_t hi;

--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -308,7 +308,7 @@
 /************************************************************************/
 
 #ifndef SEXP_64_BIT
-#if defined(__amd64) || defined(__x86_64) || defined(_WIN64) || defined(_Wp64) || defined(__LP64__) || defined(__PPC64__) || defined(__mips64__) || defined(__sparc64__)
+#if defined(__amd64) || defined(__x86_64) || defined(_WIN64) || defined(_Wp64) || defined(__LP64__) || defined(__PPC64__) || defined(__mips64__) || defined(__sparc64__) || defined(__arm64)
 #define SEXP_64_BIT 1
 #else
 #define SEXP_64_BIT 0

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -231,9 +231,15 @@ typedef int sexp_sint_t;
 #define sexp_heap_align(n) sexp_align(n, 5)
 #define sexp_heap_chunks(n) (sexp_heap_align(n)>>5)
 #elif SEXP_64_BIT
+#if PLAN9
+typedef uintptr sexp_tag_t;
+typedef uintptr sexp_uint_t;
+typedef intptr sexp_sint_t;
+#else
 typedef unsigned int sexp_tag_t;
 typedef unsigned long sexp_uint_t;
 typedef long sexp_sint_t;
+#endif
 #define SEXP_PRIdFIXNUM "ld"
 #define sexp_heap_align(n) sexp_align(n, 5)
 #define sexp_heap_chunks(n) (sexp_heap_align(n)>>5)
@@ -244,6 +250,13 @@ typedef int sexp_sint_t;
 #define SEXP_PRIdFIXNUM "d"
 #define sexp_heap_align(n) sexp_align(n, 5)
 #define sexp_heap_chunks(n) (sexp_heap_align(n)>>5)
+#elif PLAN9
+typedef uintptr sexp_tag_t;
+typedef unsigned int sexp_uint_t;
+typedef int sexp_sint_t;
+#define SEXP_PRIdFIXNUM "d"
+#define sexp_heap_align(n) sexp_align(n, 4)
+#define sexp_heap_chunks(n) (sexp_heap_align(n)>>4)
 #else
 typedef unsigned short sexp_tag_t;
 typedef unsigned int sexp_uint_t;
@@ -260,7 +273,11 @@ typedef int sexp_sint_t;
 
 
 #ifdef SEXP_USE_INTTYPES
+#ifdef PLAN9
+#include <ape/stdint.h>
+#else
 #include <stdint.h>
+#endif
 # ifdef UINT8_MAX
 #  define SEXP_UINT8_DEFINED 1
 typedef uint8_t  sexp_uint8_t;
@@ -276,7 +293,11 @@ typedef int32_t sexp_int32_t;
 # else
 # include <limits.h>
 # if SEXP_USE_UNIFORM_VECTOR_LITERALS
+# ifdef PLAN9
+# include <ape/stdint.h>
+# else
 # include <stdint.h>
+# endif
 # endif
 # endif
 # if UCHAR_MAX == 255

--- a/mkfile
+++ b/mkfile
@@ -7,7 +7,7 @@ MODDIR=/sys/lib/chibi-scheme
 CHIBI=./$O.out
 GENSTATIC=./tools/chibi-genstatic
 
-CPPFLAGS= -Iinclude -DPLAN9 -DSEXP_USE_GREEN_THREADS=0
+CPPFLAGS= -Iinclude -DPLAN9 -DSEXP_USE_GREEN_THREADS=0 -D__$objtype
 CFLAGS= -p $CPPFLAGS
 CFLAGS_STATIC=$CFLAGS -DSEXP_USE_STATIC_LIBS
 
@@ -35,7 +35,7 @@ COMPILED_LIBS = $CHIBI_COMPILED_LIBS $CHIBI_IO_COMPILED_LIBS \
 </sys/src/cmd/mkone
 
 clean:
-	rm -f $CLEANFILES
+	rm -f $CLEANFILES *.[$OS] [$OS].out
 
 clibs.$O: clibs.c
 


### PR DESCRIPTION
This fixes https://github.com/ashinn/chibi-scheme/issues/453

There are currently still library/linking issues that prevent it from running on 9front