### PR TITLE
chibi-scheme.1: document -b

### DIFF
--- a/doc/chibi-scheme.1
+++ b/doc/chibi-scheme.1
@@ -225,6 +225,10 @@ Loads the Scheme heap from
 .I image-file
 instead of compiling the init file on the fly.
 This feature is still experimental.
+.TP
+.BI -b
+Makes stdio nonblocking (blocking by default). Only available when
+lightweight threads are enabled.
 
 .SH ENVIRONMENT
 .TP

--- a/main.c
+++ b/main.c
@@ -60,6 +60,9 @@ void sexp_usage(int err) {
          "  -d <file>    - dump an image file and exit\n"
          "  -i <file>    - load an image file\n"
 #endif
+#if SEXP_USE_GREEN_THREADS
+         "  -b           - Make stdio nonblocking\n"
+#endif
          );
   if (err == 0) exit_success();
   else exit_failure();


### PR DESCRIPTION
It's added in fad9e4ca (don't make stdio nonblocking by default, allow
override with -b, 2017-05-07)