### PR TITLE
Fix documentation on building a standalone statically linked executable including compiled libs

### DIFF
--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -79,7 +79,8 @@ or edited manually.  Be sure to run this with a non-static
 chibi-scheme.  Then you can make the static executable with:
 
 \command{
-make -B chibi-scheme-static SEXP_USE_DL=0 CPPFLAGS=-DSEXP_USE_STATIC_LIBS
+make -B chibi-scheme-static SEXP_USE_DL=0 \
+  CPPFLAGS="-DSEXP_USE_STATIC_LIBS -DSEXP_USE_STATIC_LIBS_NO_INCLUDE=0"
 }
 
 By default files are installed in /usr/local.  You can optionally


### PR DESCRIPTION
This one-liner adjusts the documentation on building a standalone static executable with all compiled libraries.

If I am not mistaken, the preprocessor flag `SEXP_USE_STATIC_LIBS_NO_INCLUDE=0` must be present when compiling `eval.c` in order to include the generated `clibs.c` - otherwise `SEXP_USE_STATIC_LIBS_NO_INCLUDE` will be set to 1 in `features.h`, and I believe this is not what the docs are trying to show (also, linking fails due to a missing `sexp_static_libraries` symbol, as tested on MacOS and Linux ARM).