### PR TITLE
Initialize variables in FFI tests

### DIFF
--- a/tests/ffi/ffi-tests.scm
+++ b/tests/ffi/ffi-tests.scm
@@ -303,7 +303,7 @@ double circle_area2(struct Circle circ) {
 
 struct Point* centroid(struct Point** points, int num_points) {
   struct Point* res;
-  double xsum, ysum;
+  double xsum=0, ysum=0;
   int i;
   for (i=0; i<num_points; ++i) {
     xsum += points[i]->x;
@@ -317,7 +317,7 @@ struct Point* centroid(struct Point** points, int num_points) {
 
 struct Point* centroid_null(struct Point** points) {
   struct Point* res;
-  double xsum, ysum;
+  double xsum=0, ysum=0;
   int i;
   for (i=0; points[i]; ++i) {
     xsum += points[i]->x;


### PR DESCRIPTION
These ones are used to compute averages. If they are not initialized to zero, they might contain some garbage. In fact, they almost always do on platforms other that x86_64, failing the FFI tests. If optimizations are enabled, these tests usually fail on x86_64 too. The reason this went unnoticed is contrived set of coincidences.