### PR TITLE
(chibi math prime) fix miller-rabin-composite?, factor, etc (issue #751), add factor-alist

### DIFF
--- a/lib/chibi/math/prime-test.sld
+++ b/lib/chibi/math/prime-test.sld
@@ -71,7 +71,7 @@
       (test #t (perfect? 496))
       (test #t (perfect? 8128))
 
-      (test '(1) (factor 1))
+      (test '() (factor 1))
       (test '(2) (factor 2))
       (test '(3) (factor 3))
       (test '(2 2) (factor 4))
@@ -86,6 +86,7 @@
       (test '(2 3 3) (factor 18))
       (test '(2 2 2 3 3) (factor 72))
       (test '(3 3 3 5 7) (factor 945))
+      (test-error (factor 0))
 
       (test 975 (aliquot 945))
 

--- a/lib/chibi/math/prime-test.sld
+++ b/lib/chibi/math/prime-test.sld
@@ -107,4 +107,7 @@
                         5772301760555853353
                         (* 2936546443 3213384203)))
 
+      (test "Miller-Rabin vs. Carmichael prime"
+            #t (miller-rabin-composite? 118901521))
+
       (test-end))))

--- a/lib/chibi/math/prime-test.sld
+++ b/lib/chibi/math/prime-test.sld
@@ -90,6 +90,11 @@
       (test '(3 3 3 5 7) (factor 945))
       (test-error (factor 0))
 
+      (test '() (factor-alist 1))
+      (test '((2 . 3) (3 . 2)) (factor-alist 72))
+      (test '((3 . 3) (5 . 1) (7 . 1)) (factor-alist 945))
+      (test-error (factor-alist 0))
+
       (test 0 (aliquot 1))
       (test 975 (aliquot 945))
       (test-error (aliquot 0))

--- a/lib/chibi/math/prime-test.sld
+++ b/lib/chibi/math/prime-test.sld
@@ -47,6 +47,7 @@
       (test 5 (prime-below 7))
       (test 797 (prime-below 808))
 
+      (test 1 (totient 1))
       (test 1 (totient 2))
       (test 2 (totient 3))
       (test 2 (totient 4))
@@ -56,6 +57,7 @@
       (test 4 (totient 8))
       (test 6 (totient 9))
       (test 4 (totient 10))
+      (test-error (totient 0))
 
       (test #f (perfect? 1))
       (test #f (perfect? 2))
@@ -88,7 +90,9 @@
       (test '(3 3 3 5 7) (factor 945))
       (test-error (factor 0))
 
+      (test 0 (aliquot 1))
       (test 975 (aliquot 945))
+      (test-error (aliquot 0))
 
       (do ((i 3 (+ i 2)))
           ((>= i 101))

--- a/lib/chibi/math/prime.scm
+++ b/lib/chibi/math/prime.scm
@@ -237,31 +237,10 @@
 
 ;;> Returns the factorization of \var{n} as a monotonically
 ;;> increasing list of primes.
-(define (factor n)
-  (when (zero? n)
-    (error "cannot factor 0"))
-  (factor-twos
-   n
-   (lambda (b n)
-     (let lp ((i 3) (ii 9) (n (abs n))
-              (res (append (make-list b 2)
-                           (if (negative? n) (list -1) '()))))
-       (cond
-        ((> ii n)
-         (reverse (if (= n 1) res (cons n res))))
-        ((zero? (remainder n i))
-         (lp i ii (quotient n i) (cons i res)))
-        (else
-         (lp (+ i 2)
-             (+ ii (* (+ i 1) 4))
-             n
-             res)))))))
-;; this version is slightly slower
-;;(define factor
-;;  (let ((rfactor (make-factorizer '()
-;;                  (lambda (l p k) (cons (make-list k p) l)))))
-;;    (lambda (n) (apply append! (reverse (rfactor n))))))
-
+(define factor
+  (let ((rfactor (make-factorizer '()
+                  (lambda (l p k) (cons (make-list k p) l)))))
+    (lambda (n) (concatenate! (reverse (rfactor n))))))
 
 ;;> The Euler totient φ(\var{n}) is the number of positive
 ;;> integers less than or equal to \var{n} that are

--- a/lib/chibi/math/prime.scm
+++ b/lib/chibi/math/prime.scm
@@ -226,6 +226,15 @@
                           (lp (+ i 2) (+ ii (* (+ i 1) 4))
                               n (put res i k)))))))))))))
 
+;;> Returns the factorization of \var{n} as a list of
+;;> elements of the form \scheme{(\var{p} . \var{k})},
+;;> where \var{p} is a prime factor
+;;> and \var{k} is its multiplicity.
+(define factor-alist
+  (let ((rfactor (make-factorizer '()
+                  (lambda (l p k) (cons (cons p k) l)))))
+    (lambda (n) (reverse (rfactor n)))))
+
 ;;> Returns the factorization of \var{n} as a monotonically
 ;;> increasing list of primes.
 (define (factor n)

--- a/lib/chibi/math/prime.scm
+++ b/lib/chibi/math/prime.scm
@@ -192,30 +192,24 @@
 ;;> Returns the factorization of \var{n} as a monotonically
 ;;> increasing list of primes.
 (define (factor n)
-  (cond
-   ((negative? n)
-    (cons -1 (factor (- n))))
-   ((<= n 2)
-    (list n))
-   (else
-    (let lp ((n n)
-             (res (list)))
-      (cond
-       ((even? n)
-        (lp (quotient n 2) (cons 2 res)))
-       ((= n 1)
-        (reverse res))
-       (else
-        (let lp ((i 3) (n n) (limit (exact (ceiling (sqrt n)))) (res res))
-          (cond
-           ((= n 1)
-            (reverse res))
-           ((> i limit)
-            (reverse (cons n res)))
-           ((zero? (remainder n i))
-            (lp i (quotient n i) limit (cons i res)))
-           (else
-            (lp (+ i 2) n limit res))))))))))
+  (when (zero? n)
+    (error "cannot factor 0"))
+  (factor-twos
+   n
+   (lambda (b n)
+     (let lp ((i 3) (ii 9) (n (abs n))
+              (res (append (make-list b 2)
+                           (if (negative? n) (list -1) '()))))
+       (cond
+        ((> ii n)
+         (reverse (if (= n 1) res (cons n res))))
+        ((zero? (remainder n i))
+         (lp i ii (quotient n i) (cons i res)))
+        (else
+         (lp (+ i 2)
+             (+ ii (* (+ i 1) 4))
+             n
+             res)))))))
 
 ;;> Returns the Euler totient function, the number of positive
 ;;> integers less than \var{n} that are relatively prime to \var{n}.

--- a/lib/chibi/math/prime.sld
+++ b/lib/chibi/math/prime.sld
@@ -1,6 +1,6 @@
 
 (define-library (chibi math prime)
-  (import (scheme base) (scheme inexact) (chibi optional) (srfi 27))
+  (import (scheme base) (scheme inexact) (chibi optional) (srfi 1) (srfi 27))
   (cond-expand
    ((library (srfi 151)) (import (srfi 151)))
    ((library (srfi 33)) (import (srfi 33)))

--- a/lib/chibi/math/prime.sld
+++ b/lib/chibi/math/prime.sld
@@ -5,7 +5,8 @@
    ((library (srfi 151)) (import (srfi 151)))
    ((library (srfi 33)) (import (srfi 33)))
    (else (import (srfi 60))))
-  (export prime? nth-prime prime-above prime-below factor perfect?
+  (export prime? nth-prime prime-above prime-below
+          factor factor-alist perfect?
           totient aliquot
           provable-prime? probable-prime?
           random-prime random-prime-distinct-from

--- a/lib/chibi/math/prime.sld
+++ b/lib/chibi/math/prime.sld
@@ -1,6 +1,6 @@
 
 (define-library (chibi math prime)
-  (import (scheme base) (scheme inexact) (srfi 27))
+  (import (scheme base) (scheme inexact) (chibi optional) (srfi 27))
   (cond-expand
    ((library (srfi 151)) (import (srfi 151)))
    ((library (srfi 33)) (import (srfi 33)))


### PR DESCRIPTION
This addresses all of issues with (chibi math prime) raised with [in #751](/ashinn/chibi-scheme/issues/751) thus far

- makes `miller-rabin-composite?` not miss viable witnesses
- `factor` is faster, `(factor 1) = ()`, `(factor 0)` raises an error
- `aliquot`, `totient` are way faster, also raise errors on n=0,  `(totient 1) = 1`, `(aliquot 1) = 0`

I've also included a new export `factor-alist`, that returns the factorization as an alist with multiplicities (rather than a list of repeated primes that you then have to count) that imho is more useful than `factor`.  (This is basically a feature request; it's in a separate commit, feel free to toss or rename.)

Also included is the 4-line version of `(factor ...)` that uses `make-factorizer` similar to the new `aliquot` and `totient`, but is commented out due to being ever-so-slightly slower but which you might prefer on aesthetic/smaller-code-size grounds.