### PR TITLE
CMake update 1/3: basic modernization (preserving all current functionality)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ lib/srfi/160/uvprims.c
 *.err
 *.fasl
 *.txt
+!CMakeLists.txt
 *.test
 *.train
 *.h5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ include_directories(
 #
 
 add_executable(chibi-scheme-bootstrap
+    EXCLUDE_FROM_ALL
     ${chibi-scheme-srcs}
     main.c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,9 @@ check_include_file(poll.h HAVE_POLL_H)
 check_include_file(stdint.h HAVE_STDINT_H)
 # option(CHIBI_SCHEME_USE_DL "Use dynamic loading" ON)
 set(CHIBI_SCHEME_USE_DL OFF)
-option(CHIBI_SCHEME_SHARED "Build chibi-scheme as a shared library" ON)
+option(BUILD_SHARED_LIBS "Build chibi-scheme as a shared library" ON)
 
-if(NOT CHIBI_SCHEME_SHARED)
+if(NOT ${BUILD_SHARED_LIBS})
     add_definitions(-DSEXP_STATIC_LIBRARY=1)
 endif()
 
@@ -172,13 +172,7 @@ add_custom_command(OUTPUT ${clibout}
 # Core library
 #
 
-if(CHIBI_SCHEME_SHARED)
-    set(libtype SHARED)
-else()
-    set(libtype STATIC)
-endif()
-
-add_library(lib-chibi-scheme ${libtype}
+add_library(lib-chibi-scheme
     ${chibi-scheme-srcs}
     ${clibout})
 
@@ -188,14 +182,14 @@ set_target_properties(lib-chibi-scheme
 
 add_dependencies(lib-chibi-scheme chibi-scheme-stubs)
 
-if(WIN32 AND CHIBI_SCHEME_SHARED)
+if(WIN32 AND ${BUILD_SHARED_LIBS})
     target_link_libraries(lib-chibi-scheme ws2_32)
     target_compile_definitions(lib-chibi-scheme PUBLIC -DBUILDING_DLL=1)
 endif()
 
 function(bless_chibi_scheme_executable tgt)
     target_link_libraries(${tgt} lib-chibi-scheme)
-    if(WIN32 AND NOT CHIBI_SCHEME_SHARED)
+    if(WIN32 AND NOT ${BUILD_SHARED_LIBS})
         target_link_libraries(${tgt} ws2_32)
     endif()
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,11 +113,12 @@ add_executable(chibi-scheme-bootstrap
     ${chibi-scheme-srcs}
     main.c)
 
-target_link_libraries(chibi-scheme-bootstrap
-    PRIVATE libchibi-common)
-
 if(WIN32)
-    target_link_libraries(chibi-scheme-bootstrap ws2_32)
+    target_link_libraries(chibi-scheme-bootstrap
+        PRIVATE ws2_32 libchibi-common)
+else()
+    target_link_libraries(chibi-scheme-bootstrap
+        PRIVATE libchibi-common)
 endif()
 
 if(CYGWIN OR WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,12 @@ else()
     target_compile_definitions(libchibi-common INTERFACE SEXP_USE_DL=1)
 endif()
 
-if(NOT ${BUILD_SHARED_LIBS})
-    add_definitions(-DSEXP_STATIC_LIBRARY=1)
+if(HAVE_STDINT_H)
+    target_compile_definitions(libchibi-common INTERFACE SEXP_USE_INTTYPES)
 endif()
 
-if(HAVE_STDINT_H)
-    target_compile_definitions(libchibi-common INTERFACE SEXP_USE_INTTYPES=1)
+if(HAVE_NTP_GETTIME)
+    target_compile_definitions(libchibi-common INTERFACE SEXP_USE_NTPGETTIME)
 endif()
 
 if(NOT HAVE_POLL_H)
@@ -123,9 +123,28 @@ endif()
 
 
 #
-# Generate modules
+# Core library
 #
 
+add_library(libchibi-scheme
+    ${chibi-scheme-srcs})
+
+target_link_libraries(libchibi-scheme
+    PUBLIC libchibi-common)
+
+set_target_properties(libchibi-scheme
+    PROPERTIES
+    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+    VERSION ${CMAKE_PROJECT_VERSION})
+
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(libchibi-scheme PUBLIC SEXP_STATIC_LIBRARY=1)
+endif()
+
+
+#
+# Generate modules
+#
 # FIXME: Currently, it depends on GLOB thus we have to re-run CMake
 #        when we've gotten additional/removed library
 
@@ -155,20 +174,8 @@ foreach(e ${stubs})
 endforeach()
 add_custom_target(chibi-scheme-stubs DEPENDS ${stubouts})
 
-#
-# Core library
-#
 
-add_library(libchibi-scheme
-    ${chibi-scheme-srcs})
 
-target_link_libraries(libchibi-scheme
-    PUBLIC libchibi-common)
-
-set_target_properties(libchibi-scheme
-    PROPERTIES
-    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
-    VERSION ${CMAKE_PROJECT_VERSION})
 
 add_dependencies(libchibi-scheme chibi-scheme-stubs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,14 @@ check_include_file(poll.h HAVE_POLL_H)
 check_include_file(stdint.h HAVE_STDINT_H)
 # option(CHIBI_SCHEME_USE_DL "Use dynamic loading" ON)
 set(CHIBI_SCHEME_USE_DL OFF)
-option(BUILD_SHARED_LIBS "Build chibi-scheme as a shared library" ON)
+
+if (WIN32 AND NOT CYGWIN)
+    set(DEFAULT_SHARED_LIBS OFF)
+else()
+    set(DEFAULT_SHARED_LIBS ON)
+endif()
+
+option(BUILD_SHARED_LIBS "Build chibi-scheme as a shared library" ${DEFAULT_SHARED_LIBS})
 
 if(NOT ${BUILD_SHARED_LIBS})
     add_definitions(-DSEXP_STATIC_LIBRARY=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # FIXME: This CMakeLists.txt is only for Win32 platforms for now
 #
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.12)
 project(chibi-scheme)
 
 include(CheckIncludeFile)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 check_include_file(poll.h HAVE_POLL_H)
 check_include_file(stdint.h HAVE_STDINT_H)
-# option(CHIBI_SCHEME_USE_DL "Use dynamic loading" ON)
-set(CHIBI_SCHEME_USE_DL OFF)
 
 if (WIN32 AND NOT CYGWIN)
     set(DEFAULT_SHARED_LIBS OFF)
@@ -44,28 +42,8 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build chibi-scheme as a shared library" ${DEFAULT_SHARED_LIBS})
 
-if(NOT ${BUILD_SHARED_LIBS})
-    add_definitions(-DSEXP_STATIC_LIBRARY=1)
-endif()
-
-if(CHIBI_SCHEME_USE_DL)
-    add_definitions(-DSEXP_USE_DL=1)
-else()
-    add_definitions(-DSEXP_USE_DL=0)
-endif()
-
-if(HAVE_STDINT_H)
-    add_definitions(-DSEXP_USE_INTTYPES=1)
-endif()
-
-if(NOT HAVE_POLL_H)
-    # Disable green threads: It depends on non-blocking I/O
-    add_definitions(-DSEXP_USE_GREEN_THREADS=0)
-endif()
-
 set(chibi-scheme-exclude-modules)
 if(WIN32)
-    add_definitions(-DBUILDING_DLL)
     set(chibi-scheme-exclude-modules
         # Following modules are not compatible with Win32
         lib/chibi/net.sld
@@ -74,6 +52,39 @@ if(WIN32)
         lib/chibi/system.sld
         lib/chibi/time.sld
         lib/chibi/pty.sld)
+endif()
+
+#
+# Default settings for all targets. We use an interface library here to not
+# pollute/mutate global settings.
+#
+
+add_library(libchibi-common
+    INTERFACE)
+
+target_include_directories(libchibi-common
+    INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(libchibi-common INTERFACE SEXP_USE_DL=0)
+else()
+    target_compile_definitions(libchibi-common INTERFACE SEXP_USE_DL=1)
+endif()
+
+if(NOT ${BUILD_SHARED_LIBS})
+    add_definitions(-DSEXP_STATIC_LIBRARY=1)
+endif()
+
+if(HAVE_STDINT_H)
+    target_compile_definitions(libchibi-common INTERFACE SEXP_USE_INTTYPES=1)
+endif()
+
+if(NOT HAVE_POLL_H)
+    # Disable green threads: It depends on non-blocking I/O
+    target_compile_definitions(libchibi-common INTERFACE SEXP_USE_GREEN_THREADS=0)
 endif()
 
 #
@@ -93,10 +104,6 @@ set(chibi-scheme-srcs
     eval.c
     simplify.c)
 
-include_directories(
-    include
-    ${CMAKE_CURRENT_BINARY_DIR}/include)
-
 #
 # Bootstrap
 #
@@ -105,6 +112,9 @@ add_executable(chibi-scheme-bootstrap
     EXCLUDE_FROM_ALL
     ${chibi-scheme-srcs}
     main.c)
+
+target_link_libraries(chibi-scheme-bootstrap
+    PRIVATE libchibi-common)
 
 if(WIN32)
     target_link_libraries(chibi-scheme-bootstrap ws2_32)
@@ -156,6 +166,9 @@ add_custom_target(chibi-scheme-stubs DEPENDS ${stubouts})
 add_library(libchibi-scheme
     ${chibi-scheme-srcs})
 
+target_link_libraries(libchibi-scheme
+    PUBLIC libchibi-common)
+
 set_target_properties(libchibi-scheme
     PROPERTIES
     SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
@@ -174,7 +187,6 @@ if (NOT BUILD_SHARED_LIBS)
     set(genstatic-helper
         ${CMAKE_CURRENT_LIST_DIR}/contrib/chibi-genstatic-helper.cmake)
     file(WRITE ${clibin} "${genstatic-input}")
-
 
     add_custom_command(OUTPUT ${clibout}
         COMMAND
@@ -198,6 +210,11 @@ if (NOT BUILD_SHARED_LIBS)
     target_sources(libchibi-scheme
         PUBLIC
         ${clibout})
+
+    target_include_directories(libchibi-common
+        INTERFACE
+        $<BUILD_INTERFACE:${stuboutdir}/..>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 elseif(WIN32)
     target_link_libraries(libchibi-scheme ws2_32)
     target_compile_definitions(libchibi-scheme PUBLIC BUILDING_DLL=1)
@@ -214,9 +231,6 @@ endfunction()
 # Interpreter
 #
 
-include_directories(
-    .
-    ${stuboutdir}/..)
 add_executable(chibi-scheme
     main.c)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,11 +114,11 @@ endif()
 #
 
 # FIXME: Currently, it depends on GLOB thus we have to re-run CMake
-#        when we've gotten additional/removed library 
+#        when we've gotten additional/removed library
 
-file(GLOB_RECURSE stubs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/lib 
+file(GLOB_RECURSE stubs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/lib
     ${CMAKE_CURRENT_SOURCE_DIR}/lib/*.stub)
-file(GLOB_RECURSE slds RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} 
+file(GLOB_RECURSE slds RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/lib/*.sld)
 list(REMOVE_ITEM slds ${chibi-scheme-exclude-modules})
 
@@ -209,7 +209,7 @@ add_executable(chibi-scheme
 bless_chibi_scheme_executable(chibi-scheme)
 
 #
-# Generate "chibi/install.h" 
+# Generate "chibi/install.h"
 #
 
 if(CYGWIN OR WIN32)
@@ -246,7 +246,7 @@ file(WRITE
 #define sexp_version \"\"
 #define sexp_release_name \"${release}\"")
 
-# 
+#
 # Testing
 #
 
@@ -309,7 +309,7 @@ foreach(e ${testlibs})
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
-# 
+#
 # Testing (embedding)
 #
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,11 +121,6 @@ else()
         PRIVATE libchibi-common)
 endif()
 
-if(CYGWIN OR WIN32)
-    set(soext ".dll")
-else()
-    set(soext ".so")
-endif()
 
 #
 # Generate modules
@@ -269,7 +264,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/chibi)
 
 file(WRITE
     ${CMAKE_CURRENT_BINARY_DIR}/include/chibi/install.h
-    "#define sexp_so_extension \"${soext}\"
+    "#define sexp_so_extension \"${CMAKE_SHARED_LIBRARY_SUFFIX}\"
 #define sexp_default_module_path \"${default_module_path}\"
 #define sexp_platform \"${platform}\"
 #define sexp_version \"\"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/VERSION rawversion)
 string(STRIP ${rawversion} rawversion)
 set(version "${rawversion}-cmake")
 
-set(chibischemelib "chibi-scheme-${rawversion}")
-
 if(APPLE)
     message(FATAL_ERROR 
         "DYLD platforms are not supported with this CMakeLists.txt. Use Makefile instead.")
@@ -180,23 +178,23 @@ else()
     set(libtype STATIC)
 endif()
 
-add_library(${chibischemelib} ${libtype}
+add_library(lib-chibi-scheme ${libtype}
     ${chibi-scheme-srcs}
     ${clibout})
 
-set_target_properties(${chibischemelib}
+set_target_properties(lib-chibi-scheme
     PROPERTIES 
     COMPILE_DEFINITIONS "SEXP_USE_STATIC_LIBS=1")
 
-add_dependencies(${chibischemelib} chibi-scheme-stubs)
+add_dependencies(lib-chibi-scheme chibi-scheme-stubs)
 
 if(WIN32 AND CHIBI_SCHEME_SHARED)
-    target_link_libraries(${chibischemelib} ws2_32)
-    target_compile_definitions(${chibischemelib} PUBLIC -DBUILDING_DLL=1)
+    target_link_libraries(lib-chibi-scheme ws2_32)
+    target_compile_definitions(lib-chibi-scheme PUBLIC -DBUILDING_DLL=1)
 endif()
 
 function(bless_chibi_scheme_executable tgt)
-    target_link_libraries(${tgt} ${chibischemelib})
+    target_link_libraries(${tgt} lib-chibi-scheme)
     if(WIN32 AND NOT CHIBI_SCHEME_SHARED)
         target_link_libraries(${tgt} ws2_32)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,17 @@
 #
 
 cmake_minimum_required(VERSION 3.12)
-project(chibi-scheme)
 
-include(CheckIncludeFile)
-
-#
-# Version setting
-#
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/VERSION version)
+string(STRIP ${version} version)
 
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/RELEASE release)
 string(STRIP ${release} release)
 
-file(READ ${CMAKE_CURRENT_SOURCE_DIR}/VERSION rawversion)
-string(STRIP ${rawversion} rawversion)
-set(version "${rawversion}-cmake")
+project(chibi-scheme LANGUAGES C VERSION ${version}
+    DESCRIPTION "Chibi-Scheme: minimal r7rs implementation, release: ${release}")
+
+include(CheckIncludeFile)
 
 if(APPLE)
     message(FATAL_ERROR 
@@ -178,6 +175,8 @@ add_library(libchibi-scheme
 
 set_target_properties(libchibi-scheme
     PROPERTIES 
+    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+    VERSION ${CMAKE_PROJECT_VERSION}
     COMPILE_DEFINITIONS "SEXP_USE_STATIC_LIBS=1")
 
 add_dependencies(libchibi-scheme chibi-scheme-stubs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ if(UNIX)
         "UNIX platforms are not supported with this CMakeLists.txt. Use Makefile instead.")
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 #
 # Features
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,15 +260,7 @@ set(default_module_path
     #"${CMAKE_INSTALL_PREFIX}/${thePrefix}${pathsep}${CMAKE_INSTALL_PREFIX}/bin"
     )
 
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/chibi)
-
-file(WRITE
-    ${CMAKE_CURRENT_BINARY_DIR}/include/chibi/install.h
-    "#define sexp_so_extension \"${CMAKE_SHARED_LIBRARY_SUFFIX}\"
-#define sexp_default_module_path \"${default_module_path}\"
-#define sexp_platform \"${platform}\"
-#define sexp_version \"\"
-#define sexp_release_name \"${release}\"")
+configure_file(include/chibi/install.h.in include/chibi/install.h)
 
 #
 # Testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,23 +172,23 @@ add_custom_command(OUTPUT ${clibout}
 # Core library
 #
 
-add_library(lib-chibi-scheme
+add_library(libchibi-scheme
     ${chibi-scheme-srcs}
     ${clibout})
 
-set_target_properties(lib-chibi-scheme
+set_target_properties(libchibi-scheme
     PROPERTIES 
     COMPILE_DEFINITIONS "SEXP_USE_STATIC_LIBS=1")
 
-add_dependencies(lib-chibi-scheme chibi-scheme-stubs)
+add_dependencies(libchibi-scheme chibi-scheme-stubs)
 
 if(WIN32 AND ${BUILD_SHARED_LIBS})
-    target_link_libraries(lib-chibi-scheme ws2_32)
-    target_compile_definitions(lib-chibi-scheme PUBLIC -DBUILDING_DLL=1)
+    target_link_libraries(libchibi-scheme ws2_32)
+    target_compile_definitions(libchibi-scheme PUBLIC -DBUILDING_DLL=1)
 endif()
 
 function(bless_chibi_scheme_executable tgt)
-    target_link_libraries(${tgt} lib-chibi-scheme)
+    target_link_libraries(${tgt} libchibi-scheme)
     if(WIN32 AND NOT ${BUILD_SHARED_LIBS})
         target_link_libraries(${tgt} ws2_32)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,10 @@ endif()
 add_library(libchibi-common
     INTERFACE)
 
+if (NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(libchibi-common INTERFACE SEXP_STATIC_LIBRARY=1)
+endif()
+
 target_include_directories(libchibi-common
     INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -136,10 +140,6 @@ set_target_properties(libchibi-scheme
     PROPERTIES
     SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
     VERSION ${CMAKE_PROJECT_VERSION})
-
-if (NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(libchibi-scheme PUBLIC SEXP_STATIC_LIBRARY=1)
-endif()
 
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,50 +143,57 @@ endforeach()
 add_custom_target(chibi-scheme-stubs DEPENDS ${stubouts})
 
 #
-# Generate clib.c for SEXP_USE_STATIC_LIBS
-#
-
-string(REPLACE ";" "\n" genstatic-input "${slds}")
-set(clibin ${CMAKE_CURRENT_BINARY_DIR}/clib-in.txt)
-set(clibout ${CMAKE_CURRENT_BINARY_DIR}/clib.c)
-set(genstatic-helper 
-    ${CMAKE_CURRENT_LIST_DIR}/contrib/chibi-genstatic-helper.cmake)
-file(WRITE ${clibin} "${genstatic-input}")
-
-add_custom_command(OUTPUT ${clibout}
-    COMMAND 
-    ${CMAKE_COMMAND} 
-    -DEXEC=$<TARGET_FILE:chibi-scheme-bootstrap>
-    -DGENSTATIC=${chibi-genstatic}
-    -DSTUBS=${clibin}
-    -DOUT=${clibout}
-    -P ${genstatic-helper}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DEPENDS 
-    chibi-scheme-bootstrap
-    ${chibi-genstatic}
-    ${genstatic-helper}
-    ${slds})
-
-#
 # Core library
 #
 
 add_library(libchibi-scheme
-    ${chibi-scheme-srcs}
-    ${clibout})
+    ${chibi-scheme-srcs})
 
 set_target_properties(libchibi-scheme
-    PROPERTIES 
+    PROPERTIES
     SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
-    VERSION ${CMAKE_PROJECT_VERSION}
-    COMPILE_DEFINITIONS "SEXP_USE_STATIC_LIBS=1")
+    VERSION ${CMAKE_PROJECT_VERSION})
 
 add_dependencies(libchibi-scheme chibi-scheme-stubs)
 
-if(WIN32 AND ${BUILD_SHARED_LIBS})
+#
+# Generate clib.c for SEXP_USE_STATIC_LIBS
+#
+
+if (NOT BUILD_SHARED_LIBS)
+    string(REPLACE ";" "\n" genstatic-input "${slds}")
+    set(clibin ${CMAKE_CURRENT_BINARY_DIR}/clib-in.txt)
+    set(clibout ${CMAKE_CURRENT_BINARY_DIR}/clib.c)
+    set(genstatic-helper
+        ${CMAKE_CURRENT_LIST_DIR}/contrib/chibi-genstatic-helper.cmake)
+    file(WRITE ${clibin} "${genstatic-input}")
+
+
+    add_custom_command(OUTPUT ${clibout}
+        COMMAND
+        ${CMAKE_COMMAND}
+        -DEXEC=$<TARGET_FILE:chibi-scheme-bootstrap>
+        -DGENSTATIC=${chibi-genstatic}
+        -DSTUBS=${clibin}
+        -DOUT=${clibout}
+        -P ${genstatic-helper}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        DEPENDS
+        chibi-scheme-bootstrap
+        ${chibi-genstatic}
+        ${genstatic-helper}
+        ${slds})
+
+    target_compile_definitions(libchibi-scheme
+        PUBLIC
+        SEXP_USE_STATIC_LIBS=1)
+
+    target_sources(libchibi-scheme
+        PUBLIC
+        ${clibout})
+elseif(WIN32)
     target_link_libraries(libchibi-scheme ws2_32)
-    target_compile_definitions(libchibi-scheme PUBLIC -DBUILDING_DLL=1)
+    target_compile_definitions(libchibi-scheme PUBLIC BUILDING_DLL=1)
 endif()
 
 function(bless_chibi_scheme_executable tgt)

--- a/include/chibi/install.h.in
+++ b/include/chibi/install.h.in
@@ -1,0 +1,5 @@
+#define sexp_so_extension "@CMAKE_SHARED_LIBRARY_SUFFIX@"
+#define sexp_default_module_path "@default_module_path@"
+#define sexp_platform "@platform@"
+#define sexp_version "@CMAKE_PROJECT_VERSION@"
+#define sexp_release_name "@release@"


### PR DESCRIPTION
The existing Windows-only CMake configuration is a great foundation and seems to successfully fill the gap for most Windows users. This PR builds upon that and proposes a modernization of the `CMakeLists.txt`. `CMake` has evolved considerably over the last years - while that doesn't make it less of a pain to work with or read the hideous `CMakeLists.txt` files, there are improvements to be worth taking into account. This PR:

- Simplifies some manual configuration steps by using newer, builtin features.
- Doesn't change any behavior of the Windows build. The Appveyor CI works exactly as before.
- Increases the required CMake version to 3.12. This is still fairly conservative, 3.12 is ~4 years old now.
- Replaces global configuration of preprocessor and compiler flags by target-specific ones. This is what is commonly referred to as "modern CMake": instead of setting e.g. `SEXP_USE_INTTYPES` globally for every target, we now set it _per target_ and propagate relevant settings by "inheriting" them for other targets through `PUBLIC`, `INTERFACE` and `PRIVATE` specifier. The main benefit lies in better encapsulation and an improved integration into/with other CMake-based projects. I believe the latter is attractive for chibi, as CMake is a fairly dominant choice these days and it would be nice to allow for a seamless integration, e.g. locally with a `git submodule`) that requires nothing but `add_subdirectory(external/chibi-scheme)`, or using a global installation together with `CMake`'s `find_package(chibi-scheme)`.
- Refactors `CMakeLists.txt` to allow for a subsequent PR that lifts the platform restriction and makes a `CMake` build available for Unix-based systems.

There are two follow-up PRs for this ([PR 2/3](https://github.com/lubgr/chibi-scheme/pull/1) and [ PR 3/3](https://github.com/lubgr/chibi-scheme/pull/2)). They are in my fork of the repo, as I can't do stacked PRs from fork to origin repo - but when you consider merging this one, I can reconfigure the second one to target this repo and so on.
