### PR TITLE
Simplify snprintf usage

### DIFF
--- a/lib/chibi/accept.c
+++ b/lib/chibi/accept.c
@@ -95,7 +95,7 @@ sexp sexp_sockaddr_name (sexp ctx, sexp self, struct sockaddr* addr) {
   char buf[INET6_ADDRSTRLEN];
   /* struct sockaddr_in *sa = (struct sockaddr_in *)addr; */
   /* unsigned char *ptr = (unsigned char *)&(sa->sin_addr); */
-  /* snprintf(buf, INET6_ADDRSTRLEN, "%d.%d.%d.%d", ptr[0], ptr[1], ptr[2], ptr[3]); */
+  /* snprintf(buf, sizeof(buf), "%d.%d.%d.%d", ptr[0], ptr[1], ptr[2], ptr[3]); */
   inet_ntop(addr->sa_family,
             (addr->sa_family == AF_INET6 ?
              (void*)(&(((struct sockaddr_in6 *)addr)->sin6_addr)) :

--- a/lib/chibi/disasm.c
+++ b/lib/chibi/disasm.c
@@ -22,13 +22,13 @@
 
 static void sexp_write_pointer (sexp ctx, void *p, sexp out) {
   char buf[32];
-  snprintf(buf, 32, "%p", p);
+  snprintf(buf, sizeof(buf), "%p", p);
   sexp_write_string(ctx, buf, out);
 }
 
 static void sexp_write_integer (sexp ctx, sexp_sint_t n, sexp out) {
   char buf[32];
-  snprintf(buf, 32, SEXP_PRId, n);
+  snprintf(buf, sizeof(buf), SEXP_PRId, n);
   sexp_write_string(ctx, buf, out);
 }
 

--- a/main.c
+++ b/main.c
@@ -186,14 +186,12 @@ static sexp_uint_t multiplier (char c) {
 #endif
 
 static char* make_import(const char* prefix, const char* mod, const char* suffix) {
-  int preflen = strlen(prefix), modlen = strlen(mod);
-  int len = preflen + modlen + strlen(suffix);
-  int suflen = strlen(suffix) + (mod[0] == '(' ? 1 : 0);
-  char *p, *impmod = (char*) malloc(len+1);
-  snprintf(impmod, len, "%s", prefix);
-  snprintf(impmod+preflen, len-preflen, "%s", mod[0] == '(' ? mod + 1 : mod);
-  snprintf(impmod+len-suflen, suflen+1, "%s", suffix);
-  impmod[len] = '\0';
+  char *impmod, *p;
+  size_t impmodsize;
+  if (mod[0] == '(') mod++;
+  impmodsize = strlen(prefix) + strlen(mod) + strlen(suffix) + 1;
+  impmod = (char*) malloc(impmodsize);
+  snprintf(impmod, impmodsize, "%s%s%s", prefix, mod, suffix);
   for (p=impmod; *p; p++)
     if (*p == '.') *p=' ';
   return impmod;

--- a/sexp.c
+++ b/sexp.c
@@ -2173,11 +2173,11 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out, sexp_sint_t bound) {
       } else
 #endif
       {
-        i = snprintf(numbuf, NUMBUF_LEN, "%.15lg", f);
+        i = snprintf(numbuf, sizeof(numbuf), "%.15lg", f);
         if (sscanf(numbuf, "%lg", &ftmp) == 1 && ftmp != f) {
-          i = snprintf(numbuf, NUMBUF_LEN, "%.16lg", f);
+          i = snprintf(numbuf, sizeof(numbuf), "%.16lg", f);
           if (sscanf(numbuf, "%lg", &ftmp) == 1 && ftmp != f) {
-            i = snprintf(numbuf, NUMBUF_LEN, "%.17lg", f);
+            i = snprintf(numbuf, sizeof(numbuf), "%.17lg", f);
           }
         }
         if (!strchr(numbuf, '.') && !strchr(numbuf, 'e')) {
@@ -2310,7 +2310,7 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out, sexp_sint_t bound) {
         if (i!=0) sexp_write_char(ctx, ' ', out);
 #if SEXP_BYTEVECTOR_HEX_LITERALS
 	if (str[i]) {
-	  snprintf(buf, 5, "#x%02hhX", ((unsigned char*) str)[i]);
+          snprintf(buf, sizeof(buf), "#x%02hhX", ((unsigned char*) str)[i]);
 	  sexp_write_string(ctx, buf, out);
 	} else {
 	  sexp_write_char (ctx, '0', out);
@@ -2365,7 +2365,7 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out, sexp_sint_t bound) {
       break;
     }
   } else if (sexp_fixnump(obj)) {
-    snprintf(numbuf, NUMBUF_LEN, "%" SEXP_PRIdFIXNUM, (sexp_sint_t)sexp_unbox_fixnum(obj));
+    snprintf(numbuf, sizeof(numbuf), "%" SEXP_PRIdFIXNUM, (sexp_sint_t)sexp_unbox_fixnum(obj));
     sexp_write_string(ctx, numbuf, out);
 #if SEXP_USE_IMMEDIATE_FLONUMS
   } else if (sexp_flonump(obj)) {
@@ -2377,7 +2377,7 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out, sexp_sint_t bound) {
     } else
 #endif
     {
-      i = snprintf(numbuf, NUMBUF_LEN, "%.8g", f);
+      i = snprintf(numbuf, sizeof(numbuf), "%.8g", f);
       if (f == trunc(f) && ! strchr(numbuf, '.')) {
         numbuf[i++] = '.'; numbuf[i++] = '0'; numbuf[i++] = '\0';
       }

--- a/tools/chibi-ffi
+++ b/tools/chibi-ffi
@@ -642,7 +642,7 @@
                     errnos)
 
              "  }
-  snprintf(buf, 64, \"unknown error: %d\", err);
+  snprintf(buf, sizeof(buf), \"unknown error: %d\", err);
   return buf;
 }")))))))
 


### PR DESCRIPTION
`snprintf(buf, sizeof(buf), ...)` is the canonical idiom.