### PR TITLE
Eliminate uses of strncpy()

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -2433,7 +2433,6 @@ sexp sexp_load_standard_ports (sexp ctx, sexp env, FILE* in, FILE* out,
 }
 
 sexp sexp_load_standard_env (sexp ctx, sexp e, sexp version) {
-  int len;
   char init_file[128];
   sexp_gc_var3(op, tmp, sym);
   sexp_gc_preserve3(ctx, op, tmp, sym);
@@ -2451,11 +2450,11 @@ sexp sexp_load_standard_env (sexp ctx, sexp e, sexp version) {
   sexp_global(ctx, SEXP_G_ERR_HANDLER)
     = sexp_env_ref(ctx, e, sym=sexp_intern(ctx, "current-exception-handler", -1), SEXP_FALSE);
   /* load init-7.scm */
-  len = strlen(sexp_init_file);
-  strncpy(init_file, sexp_init_file, len+1);
-  init_file[len] = (char)sexp_unbox_fixnum(version) + '0';
-  strncpy(init_file + len + 1, sexp_init_file_suffix, strlen(sexp_init_file_suffix)+1);
-  init_file[len + 1 + strlen(sexp_init_file_suffix)] = 0;
+  snprintf(init_file, sizeof(init_file),
+           "%s%d%s",
+           sexp_init_file,
+           (int)(sexp_unbox_fixnum(version)),
+           sexp_init_file_suffix);
   tmp = sexp_load_module_file(ctx, init_file, e);
   sexp_set_parameter(ctx, e, sexp_global(ctx, SEXP_G_INTERACTION_ENV_SYMBOL), e);
   /* load and bind meta-7.scm env */

--- a/sexp.c
+++ b/sexp.c
@@ -2168,8 +2168,9 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out, sexp_sint_t bound) {
       f = sexp_flonum_value(obj);
 #if SEXP_USE_INFINITIES
       if (isinf(f) || isnan(f)) {
-        numbuf[0] = (isinf(f) && f < 0 ? '-' : '+');
-        strncpy(numbuf+1, isinf(f) ? "inf.0" : "nan.0", NUMBUF_LEN-1);
+        snprintf(numbuf, sizeof(numbuf), "%c%s",
+                 (isinf(f) && f < 0 ? '-' : '+'),
+                 (isinf(f) ? "inf.0" : "nan.0"));
       } else
 #endif
       {
@@ -2372,8 +2373,9 @@ sexp sexp_write_one (sexp ctx, sexp obj, sexp out, sexp_sint_t bound) {
     f = sexp_flonum_value(obj);
 #if SEXP_USE_INFINITIES
     if (isinf(f) || isnan(f)) {
-      numbuf[0] = (isinf(f) && f < 0 ? '-' : '+');
-      strncpy(numbuf+1, isinf(f) ? "inf.0" : "nan.0", NUMBUF_LEN-1);
+      snprintf(numbuf, sizeof(numbuf), "%c%s",
+               (isinf(f) && f < 0 ? '-' : '+'),
+               (isinf(f) ? "inf.0" : "nan.0"));
     } else
 #endif
     {

--- a/tests/ffi/ffi-tests.scm
+++ b/tests/ffi/ffi-tests.scm
@@ -190,7 +190,7 @@ char* my_getcwd(char* buf, int len) {
   char* res = test_cwd;
   int needed = strlen(res);
   if (needed >= len) return NULL;
-  strncpy(buf, res, needed+1);
+  memcpy(buf, res, needed+1);
   return res;
 }
 ")
@@ -443,8 +443,7 @@ int getpwnam_x(char* name, struct password* pwd, char* buf,
   for (i=0; i < sizeof(etc_passwd) / sizeof(etc_passwd[0]); i++) {
     entry = etc_passwd[i];
     if (strstr(entry, name) == entry && entry[strlen(name)] == ':') {
-      strncpy(buf, entry, bufsize);
-      buf[strlen(entry)] = 0;
+      snprintf(buf, bufsize, \"%s\", entry);
       buf[strlen(name)] = 0;
       pwd->pw_name = buf;
       pwd->pw_passwd = buf + strlen(name) + 1;

--- a/tools/chibi-ffi
+++ b/tools/chibi-ffi
@@ -2302,12 +2302,13 @@
                (any input-env-string? (func-scheme-args f))))
          *funcs*)
     (cat "static char* sexp_concat_env_string (sexp x) {\n"
+         "  char *k=sexp_string_data(sexp_car(x)), *v=sexp_string_data(sexp_cdr(x));\n"
          "  int klen=sexp_string_size(sexp_car(x)), vlen=sexp_string_size(sexp_cdr(x));\n"
-         "  char *res = (char*) calloc(1, klen+vlen+2);\n"
-         "  strncpy(res, sexp_string_data(sexp_car(x)), klen);\n"
-         "  res[sexp_string_size(sexp_car(x))] = '=';\n"
-         "  strncpy(res+sexp_string_size(sexp_car(x)), sexp_string_data(sexp_cdr(x)), vlen);\n"
-         "  res[len-1] = '\\0';\n"
+         "  int ressize=klen+1+vlen+1;\n"
+         "  char *res = (char*) calloc(1, ressize);\n"
+         "  memcpy(res, k, klen);\n"
+         "  res[klen] = '=';\n"
+         "  memcpy(res+klen+1, v, vlen);\n"
          "  return res;\n"
          "}\n\n"))))
 


### PR DESCRIPTION
Can be replaced with memcpy() or snprintf().