### PR TITLE
Fix SRFI 227 exports

### DIFF
--- a/lib/srfi/227.sld
+++ b/lib/srfi/227.sld
@@ -2,7 +2,5 @@
   (export opt-lambda
           (rename opt-lambda* opt*-lambda)
           let-optionals
-          let-optionals*
-          (rename define-opt define-optionals)
-          (rename define-opt* define-optionals*))
+          let-optionals*)
   (import (chibi optional)))

--- a/lib/srfi/227/definition.sld
+++ b/lib/srfi/227/definition.sld
@@ -1,0 +1,4 @@
+(define-library (srfi 227 definition)
+  (export (rename define-opt define-optionals)
+          (rename define-opt* define-optionals*))
+  (import (chibi optional)))


### PR DESCRIPTION
SRFI 227 says that the definition syntax is exported in `(srfi 227 definition)`.