### PR TITLE
Add reference-barrier to (srfi 124)

### DIFF
--- a/lib/srfi/124.sld
+++ b/lib/srfi/124.sld
@@ -1,4 +1,6 @@
 (define-library (srfi 124)
   (export make-ephemeron ephemeron? ephemeron-broken?
-          ephemeron-key ephemeron-datum)
-  (import (rename (chibi weak) (ephemeron-value ephemeron-datum))))
+          ephemeron-key ephemeron-datum reference-barrier)
+  (import (rename (chibi weak) (ephemeron-value ephemeron-datum)))
+  (begin
+    (define (reference-barrier k) (if #f #f))))


### PR DESCRIPTION
According to a post-finalization note in SRFI 124, this procedure is now mandatory. Its purpose is not entirely clear to me (nor was it to Vyzo when I implemented SRFI 124 for Gerbil), but I think this should be an acceptable implementation for Chibi’s GC.