### PR TITLE
Add support for foreign procedures with a rest argument

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -2143,7 +2143,7 @@ sexp sexp_make_foreign (sexp ctx, const char *name, int num_args,
   sexp_gc_var1(res);
   sexp_gc_preserve1(ctx, res);
 #if ! SEXP_USE_EXTENDED_FCALL
-  if (num_args > 4)
+  if (num_args > (3 + !(flags & 32))))
     return sexp_user_exception(ctx, NULL, "make-foreign: exceeded foreign arg limit",
                                sexp_make_fixnum(num_args));
 #endif
@@ -2155,7 +2155,7 @@ sexp sexp_make_foreign (sexp ctx, const char *name, int num_args,
   else
 #endif
     sexp_opcode_code(res) = SEXP_OP_FCALL1+num_args-1;
-  if (flags & 1) num_args--;
+  if ((flags & 33) == 1) num_args--;
   sexp_opcode_num_args(res) = num_args;
   sexp_opcode_flags(res) = flags;
   sexp_opcode_name(res) = sexp_c_string(ctx, name, -1);

--- a/include/chibi/eval.h
+++ b/include/chibi/eval.h
@@ -192,6 +192,7 @@ SEXP_API sexp sexp_char_downcase(sexp ctx, sexp self, sexp_sint_t n, sexp ch);
 SEXP_API sexp sexp_define_foreign_param_aux(sexp ctx, sexp env, const char *name, int num_args, const char *fname, sexp_proc1 f, const char *param);
 
 #define sexp_define_foreign(c,e,s,n,f) sexp_define_foreign_aux(c,e,s,n,0,(const char*)#f,(sexp_proc1)f,NULL)
+#define sexp_define_foreign_rest(c,e,s,n,f) sexp_define_foreign_aux(c,e,s,n,33,(const char*)#f,(sexp_proc1)f,NULL)
 #define sexp_define_foreign_param(c,e,s,n,f,p) sexp_define_foreign_param_aux(c,e,s,n,(const char*)#f,(sexp_proc1)f,p)
 #define sexp_define_foreign_opt(c,e,s,n,f,p) sexp_define_foreign_aux(c,e,s,n,1,(const char*)#f,(sexp_proc1)f,p)
 

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -1317,6 +1317,7 @@ enum sexp_uniform_vector_type {
 #define sexp_opcode_ref_trans_p(x) (sexp_opcode_flags(x) & 4)
 #define sexp_opcode_static_param_p(x) (sexp_opcode_flags(x) & 8)
 #define sexp_opcode_tail_call_p(x) (sexp_opcode_flags(x) & 16)
+#define sexp_opcode_with_rest_p(x) (sexp_opcode_flags(x) & 32)
 
 #define sexp_lambda_name(x)        (sexp_field(x, lambda, SEXP_LAMBDA, name))
 #define sexp_lambda_params(x)      (sexp_field(x, lambda, SEXP_LAMBDA, params))

--- a/opt/fcall.c
+++ b/opt/fcall.c
@@ -35,3 +35,25 @@ sexp sexp_fcall (sexp ctx, sexp self, sexp_sint_t n, sexp f) {
   default: return sexp_user_exception(ctx, self, "too many FFI arguments", f);
   }
 }
+
+sexp sexp_fcall_with_rest (sexp ctx, sexp self, sexp_sint_t n, sexp f, sexp t) {
+  sexp *stack = sexp_stack_data(sexp_context_stack(ctx));
+  sexp_sint_t top = sexp_context_top(ctx);
+  switch (n) {
+  case 4: return ((sexp_proc6)sexp_opcode_func(f))(ctx, f, 4, _A(1), _A(2), _A(3), _A(4), t);
+  case 5: return ((sexp_proc7)sexp_opcode_func(f))(ctx, f, 5, _A(1), _A(2), _A(3), _A(4), _A(5), t);
+  case 6: return ((sexp_proc8)sexp_opcode_func(f))(ctx, f, 6, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), t);
+  case 7: return ((sexp_proc9)sexp_opcode_func(f))(ctx, f, 7, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), t);
+  case 8: return ((sexp_proc10)sexp_opcode_func(f))(ctx, f, 8, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), t);
+  case 9: return ((sexp_proc11)sexp_opcode_func(f))(ctx, f, 9, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), t);
+  case 10: return ((sexp_proc12)sexp_opcode_func(f))(ctx, f, 10, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), t);
+  case 11: return ((sexp_proc13)sexp_opcode_func(f))(ctx, f, 11, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), _A(11), t);
+  case 12: return ((sexp_proc14)sexp_opcode_func(f))(ctx, f, 12, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), _A(11), _A(12), t);
+  case 13: return ((sexp_proc15)sexp_opcode_func(f))(ctx, f, 13, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), _A(11), _A(12), _A(13), t);
+  case 14: return ((sexp_proc16)sexp_opcode_func(f))(ctx, f, 14, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), _A(11), _A(12), _A(13), _A(14), t);
+  case 15: return ((sexp_proc17)sexp_opcode_func(f))(ctx, f, 15, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), _A(11), _A(12), _A(13), _A(14), _A(15), t);
+  case 16: return ((sexp_proc18)sexp_opcode_func(f))(ctx, f, 16, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), _A(11), _A(12), _A(13), _A(14), _A(15), _A(16), t);
+  case 17: return ((sexp_proc19)sexp_opcode_func(f))(ctx, f, 17, _A(1), _A(2), _A(3), _A(4), _A(5), _A(6), _A(7), _A(8), _A(9), _A(10), _A(11), _A(12), _A(13), _A(14), _A(15), _A(16), _A(17), t);
+  default: return sexp_user_exception(ctx, self, "too many FFI arguments", f);
+  }
+}

--- a/vm.c
+++ b/vm.c
@@ -1326,44 +1326,87 @@ sexp sexp_apply (sexp ctx, sexp proc, sexp args) {
     _ALIGN_IP();
     sexp_context_top(ctx) = top;
     sexp_context_last_fp(ctx) = fp;
-    tmp1 = ((sexp_proc1)sexp_opcode_func(_WORD0))(ctx, _WORD0, 0);
+    if (sexp_opcode_with_rest_p(_WORD0)) {
+      tmp2 = SEXP_NULL;
+      for (j = fp + 4; top - j > 0; j++) {
+        tmp2 = sexp_cons(ctx, stack[j], tmp2);
+      }
+      tmp1 = ((sexp_proc2)sexp_opcode_func(_WORD0))(ctx, _WORD0, 0, tmp2);
+    } else {
+      tmp1 = ((sexp_proc1)sexp_opcode_func(_WORD0))(ctx, _WORD0, 0);
+    }
     sexp_fcall_return(tmp1, -1)
     break;
   case SEXP_OP_FCALL1:
     _ALIGN_IP();
     sexp_context_top(ctx) = top;
     sexp_context_last_fp(ctx) = fp;
-    tmp1 = ((sexp_proc2)sexp_opcode_func(_WORD0))(ctx, _WORD0, 1, _ARG1);
+    if (sexp_opcode_with_rest_p(_WORD0)) {
+      tmp2 = SEXP_NULL;
+      for (j = fp + 4; top - j > 1; j++) {
+        tmp2 = sexp_cons(ctx, stack[j], tmp2);
+      }
+      tmp1 = ((sexp_proc3)sexp_opcode_func(_WORD0))(ctx, _WORD0, 1, _ARG1, tmp2);
+    } else {
+      tmp1 = ((sexp_proc2)sexp_opcode_func(_WORD0))(ctx, _WORD0, 1, _ARG1);
+    }
     sexp_fcall_return(tmp1, 0)
     break;
   case SEXP_OP_FCALL2:
     _ALIGN_IP();
     sexp_context_top(ctx) = top;
     sexp_context_last_fp(ctx) = fp;
-    tmp1 = ((sexp_proc3)sexp_opcode_func(_WORD0))(ctx, _WORD0, 2, _ARG1, _ARG2);
+    if (sexp_opcode_with_rest_p(_WORD0)) {
+      tmp2 = SEXP_NULL;
+      for (j = fp + 4; top - j > 2; j++) {
+        tmp2 = sexp_cons(ctx, stack[j], tmp2);
+      }
+      tmp1 = ((sexp_proc4)sexp_opcode_func(_WORD0))(ctx, _WORD0, 2, _ARG1, _ARG2, tmp2);
+    } else {
+      tmp1 = ((sexp_proc3)sexp_opcode_func(_WORD0))(ctx, _WORD0, 2, _ARG1, _ARG2);
+    }
     sexp_fcall_return(tmp1, 1)
     break;
   case SEXP_OP_FCALL3:
     _ALIGN_IP();
     sexp_context_top(ctx) = top;
     sexp_context_last_fp(ctx) = fp;
-    tmp1 = ((sexp_proc4)sexp_opcode_func(_WORD0))(ctx, _WORD0, 3, _ARG1, _ARG2, _ARG3);
+    if (sexp_opcode_with_rest_p(_WORD0)) {
+      tmp2 = SEXP_NULL;
+      for (j = fp + 4; top - j > 3; j++) {
+        tmp2 = sexp_cons(ctx, stack[j], tmp2);
+      }
+      tmp1 = ((sexp_proc5)sexp_opcode_func(_WORD0))(ctx, _WORD0, 3, _ARG1, _ARG2, _ARG3, tmp2);
+    } else {
+      tmp1 = ((sexp_proc4)sexp_opcode_func(_WORD0))(ctx, _WORD0, 3, _ARG1, _ARG2, _ARG3);
+    }
     sexp_fcall_return(tmp1, 2)
     break;
   case SEXP_OP_FCALL4:
-    _ALIGN_IP();
-    sexp_context_top(ctx) = top;
-    sexp_context_last_fp(ctx) = fp;
-    tmp1 = ((sexp_proc5)sexp_opcode_func(_WORD0))(ctx, _WORD0, 4, _ARG1, _ARG2, _ARG3, _ARG4);
-    sexp_fcall_return(tmp1, 3)
-    break;
+    if (!sexp_opcode_with_rest_p(_WORD0)) {
+      _ALIGN_IP();
+      sexp_context_top(ctx) = top;
+      sexp_context_last_fp(ctx) = fp;
+      tmp1 = ((sexp_proc5)sexp_opcode_func(_WORD0))(ctx, _WORD0, 4, _ARG1, _ARG2, _ARG3, _ARG4);
+      sexp_fcall_return(tmp1, 3)
+        break;
+    }
 #if SEXP_USE_EXTENDED_FCALL
   case SEXP_OP_FCALLN:
     _ALIGN_IP();
     sexp_context_top(ctx) = top;
     sexp_context_last_fp(ctx) = fp;
-    i = sexp_opcode_num_args(_WORD0) + sexp_opcode_variadic_p(_WORD0);
-    tmp1 = sexp_fcall(ctx, self, i, _WORD0);
+    if (sexp_opcode_with_rest_p(_WORD0)) {
+      i = sexp_opcode_num_args(_WORD0);
+      tmp2 = SEXP_NULL;
+      for (j = fp + 4; top - j > i; j++) {
+        tmp2 = sexp_cons(ctx, stack[j], tmp2);
+      }
+      tmp1 = sexp_fcall_with_rest(ctx, self, i, _WORD0, tmp2);
+    } else {
+      i = sexp_opcode_num_args(_WORD0) + sexp_opcode_variadic_p(_WORD0);
+      tmp1 = sexp_fcall(ctx, self, i, _WORD0);
+    }
     sexp_fcall_return(tmp1, i-1)
     break;
 #endif


### PR DESCRIPTION
One inconvenience I've encountered, in attempting to embed chibi-scheme, is that I needed to expose C functionality in the form of Scheme procedures that can be invoked with various sets of arguments, so that the existing `sexp_define_foreign_opt` and `sexp_define_foreign_param` interfaces are not sufficient.  (Another use of C functions invoked with all their (Scheme) arguments gathered in a single (C) `rest` argument, is that it makes it easier to expose multiple similar C functions using macro/template trickery,)

This has been discussed to some extent in #529, where the focus seemed to be on supporting variadic C functions.  The workaround described there, works for me as well, but is not ideal in that, for instance, errors are reported inside the wrapped function, which the user knows nothing about.

This PR, which should be treated as a proof-of-concept implementation only at this point, attempts to support foreign procedures which take a certain number of arguments plus an implicit "rest" argument.  For example, a function defined as

```C
sexp foobar(sexp ctx, sexp self, sexp n, sexp arg1, sexp arg2, sexp arg3, sexp rest);
sexp_define_foreign_rest(ctx, sexp_context_env(ctx), "foobar", 3, foobar);
```
and invoked as
```Scheme
(foobar 1 2 3 4 5 6)
```
will be invoked at the C level as if by
```Scheme
(foobar 1 2 3 '(4 5 6))
```

It seems to work ok, as far as I can see (even when invoked through `apply`), but it can probably be implemented in a better way.  Let me know if the functionality introduced by the PR is considered useful and suitable for merging in principle and if so, what you think can/should be improved.