### PR TITLE
Build fails with SEXP_USE_MALLOC

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -37,7 +37,7 @@ static sexp_heap sexp_heap_last (sexp_heap h) {
   return h;
 }
 
-#if !SEXP_USE_FIXED_CHUNK_SIZE_HEAPS
+#if !SEXP_USE_FIXED_CHUNK_SIZE_HEAPS && !SEXP_USE_MALLOC
 static size_t sexp_heap_total_size (sexp_heap h) {
   size_t total_size = 0;
   for (; h; h=h->next)
@@ -696,6 +696,7 @@ int sexp_find_fixed_chunk_heap_usage(sexp ctx, size_t size, size_t* sum_freed, s
 }
 #endif
 
+#if ! SEXP_USE_MALLOC
 void* sexp_alloc (sexp ctx, size_t size) {
   void *res;
   size_t max_freed, sum_freed, total_size=0;
@@ -741,6 +742,7 @@ void* sexp_alloc (sexp ctx, size_t size) {
 #endif
   return res;
 }
+#endif
 
 
 void sexp_gc_init (void) {


### PR DESCRIPTION
This is really an issue, not a PR.  It's not something I particularly need, but during the investigation of a bug I suspected to be due to the GC, I tried defining `SEXP_USE_MALLOC`, to see whether the behavior would change.  This resulted in a couple of C compile errors, which I fixed, but building just fails a bit later when building Scheme library stubs.  I didn't pursue the failure further, but I though I'd report it.

(Unless I'm missing something, this seems to be broken for quite a while - at least since 0.8, so if it has gone undetected until now, perhaps doing away with it altogether would be appropriate.)