### PR TITLE
Export sexp_get_stack_trace

### DIFF
--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -1756,6 +1756,7 @@ SEXP_API sexp sexp_file_exception (sexp ctx, sexp self, const char *msg, sexp x)
 SEXP_API sexp sexp_type_exception (sexp ctx, sexp self, sexp_uint_t type_id, sexp x);
 SEXP_API sexp sexp_xtype_exception (sexp ctx, sexp self, const char *msg, sexp x);
 SEXP_API sexp sexp_range_exception (sexp ctx, sexp obj, sexp start, sexp end);
+SEXP_API sexp sexp_get_stack_trace (sexp ctx);
 SEXP_API sexp sexp_print_exception_op (sexp ctx, sexp self, sexp_sint_t n, sexp exn, sexp out);
 SEXP_API sexp sexp_stack_trace_op (sexp ctx, sexp self, sexp_sint_t n, sexp out);
 SEXP_API sexp sexp_print_exception_stack_trace_op (sexp ctx, sexp self, sexp_sint_t n, sexp exn, sexp out);


### PR DESCRIPTION
As far as I can see, there is no other way to get the current stack, at least not in a form that can be used arbitrarily instead of just printed to an output port.  (There is `sexp_exception_stack_trace` of course, but I assume that's just for exceptions).

For concreteness, my use case is roughly this:  I have procedures exported to Scheme, that can be called to create objects at the C/C++ level.  I would like to inspect the stack at the time of creation, i.e. within the call to the exported procedure, in order to get the location in the source where the object is created, for use in diagnostic messages to the user.  If there is some existing way of doing this, please let me know.

Since we're on the matter, I notice that stack traces (obtained via the function exported in this PR, or via `sexp_exception_stack_trace`) seem to be incomplete.  Consider for instance a foreign procedure defined as

```C
static sexp foo(sexp ctx, sexp self, sexp_sint_t n, sexp x)
{
    sexp_assert_type(ctx, sexp_realp, SEXP_NUMBER, x);

    /* ... */

    return SEXP_VOID;
}
```
and exported via

```C
sexp_define_foreign(ctx, env, "foo", 1, foo);
```

If I call it from a file named, say `test.scm`, containing:

```Scheme
(foo "foo")
```

Then the stack trace I get from the thrown exception looks like:

```
#0 /usr/local/share/chibi/init-7.scm:1264
#1 /usr/local/share/chibi/init-7.scm:796
```

If I change the call to, say `(foo 42)`, and get the stack trace via `sexp_get_stack_trace` from within the C `foo` function, I get the same trace.  In any case, no stack frame with location within `test.scm` appears.

If I wrap `foo` in another function as in

```Scheme
(define (bar x) (foo x))

(display (bar "foo"))
```
I now get a more complete stack trace:

```
#0 test.scm:3
#1 /usr/local/share/chibi/init-7.scm:1264
#2 /usr/local/share/chibi/init-7.scm:796
```

But this seems to work only when the call is wrapped in another call (as in `display` here).  Am I doing something wrong?  If not, is there some way of getting a complete strack trace consistently?  (If work is required on the Chibi-Scheme side, I could *try* to help out, given some pointers.)