### PR TITLE
Implement SRFI 213 (Identifier properties)

### DIFF
--- a/lib/chibi/syntax-case.scm
+++ b/lib/chibi/syntax-case.scm
@@ -23,7 +23,7 @@
             (old-renamer (current-renamer)))
         (current-usage-environment use-env)
         (current-renamer (make-renamer mac-env))
-        (let ((result (transformer expr)))
+        (let ((result (capture-lookup-wrap use-env (transformer expr))))
           (current-usage-environment old-use-env)
           (current-renamer old-renamer)
           result))))

--- a/lib/init-7.scm
+++ b/lib/init-7.scm
@@ -133,22 +133,32 @@
        '()))
     rename))
 
+(define capture-lookup-wrap
+  (lambda (use-env expansion)
+    (if (procedure? expansion)
+        (expansion use-env)
+        expansion)))
+
 (define sc-macro-transformer
   (lambda (f)
     (lambda (expr use-env mac-env)
-      (close-syntax (f expr use-env) mac-env))))
+      (close-syntax
+       (capture-lookup-wrap use-env (f expr use-env))
+       mac-env))))
 
 (define rsc-macro-transformer
   (lambda (f)
     (lambda (expr use-env mac-env)
-      (f expr mac-env))))
+      (capture-lookup-wrap use-env (f expr mac-env)))))
 
 (define er-macro-transformer
   (lambda (f)
     (lambda (expr use-env mac-env)
-      (f expr
-         (make-renamer mac-env)
-         (lambda (x y) (identifier=? use-env x use-env y))))))
+      (capture-lookup-wrap
+       use-env
+       (f expr
+          (make-renamer mac-env)
+          (lambda (x y) (identifier=? use-env x use-env y)))))))
 
 (define-syntax cond
   (er-macro-transformer

--- a/lib/srfi/213.scm
+++ b/lib/srfi/213.scm
@@ -1,0 +1,50 @@
+(define id-comparator
+  (make-pair-comparator eq-comparator eq-comparator))
+(define *identifier-properties* (make-hash-table id-comparator))
+
+(define-syntax define-property
+  (lambda (expr use-env mac-env)
+    (let* ((id (cadr expr))
+           (id-cell
+            (or (env-cell use-env id)
+                (error "can't attach property to unbound identifier" id)))
+           (key (car (cddr expr)))
+           (key-cell
+            (or (env-cell use-env key)
+                (error "identifier property key must be a bound identifier" key)))
+           (value (eval (cadr (cddr expr)) use-env))
+           (this-id-props
+            (hash-table-intern! *identifier-properties*
+                                (cons use-env id-cell)
+                                (lambda ()
+                                  (make-hash-table id-comparator)))))
+      (hash-table-set! this-id-props
+                       (cons use-env key-cell)
+                       value)
+      (if #f #f))))
+
+(define (capture-lookup proc)
+  (lambda (use-env)
+    (proc
+     (letrec
+         ((f
+           (case-lambda
+             ((id key)
+              (f use-env id use-env key))
+             ((id-env id key-env key)
+              (let ((cell (env-cell id-env id)))
+                (cond ((not cell)
+                       (error "identifier not bound in environment"
+                              id id-env))
+                      ((hash-table-ref/default
+                        *identifier-properties*
+                        (cons id-env cell)
+                        #f)
+                       =>
+                       (lambda (this-id-props)
+                         (hash-table-ref/default
+                          this-id-props
+                          (cons key-env (env-cell key-env key))
+                          #f)))
+                      (else #f)))))))
+       f))))

--- a/lib/srfi/213.sld
+++ b/lib/srfi/213.sld
@@ -1,0 +1,9 @@
+(define-library (srfi 213)
+  (import (chibi)
+          (chibi ast)
+          (scheme case-lambda)
+          (scheme comparator)
+          (scheme hash-table))
+  (export define-property
+          capture-lookup)
+  (include "213.scm"))


### PR DESCRIPTION
This implementation is really not very good at all, but at the moment I can’t see a better way without significantly digging into Chibi’s core. It should suffice for most simple uses of identifier properties, but has some funky scoping and other undesirable behaviour.

Here are the problems:
- Identifier properties are stored in a global nested hash table. This means that any env containing a cell which has a property attached to its binding will never get GC’d. (Chibi still seems to lack weak hash tables which would fix this problem?)
- Because define-property isn’t recognized by the core macro expander, it sees it as an expression rather than as a definition.
- The implementation of `capture-lookup` is arguably not faithful to the requirement that ‘`capture-lookup` must be substitutable by the identity (lambda (proc) proc) when used in macro transformers, but I’m not really sure what that’s meant to mean. (Why have `capture-lookup` at all if it’s practically an identity function?)

Because of these and possibly for other reasons, it passes nearly none of Jim Rees’s advanced [tests](https://github.com/scheme-requests-for-implementation/srfi-213/blob/master/tests/srfi-213-tests.sch) it can with this definition of `identifier-property`:

```scheme
(define-syntax identifier-property
  (er-macro-transformer
   (lambda (expr rename compare)
     (capture-lookup
      (lambda (lookup)
        (list (rename 'quote)
              (lookup (cadr expr) (car (cddr expr)))))))))
```

- [x] ‘The second define-property overwrites the first one in a spliced context’ passes 
- [ ] ‘The macro picks up the outer definition’ fails for reasons I don’t understand
- [ ] ‘Demonstrate that properties can be fetched at higher phases too’ skipped because it involves mixing `with-syntax` and `syntax-rules`
- [ ] ‘property settings behave like macro definitions’ fails because of the second problem described above
- [x] ‘the 'key' identifier can be "introduced" by a macro and the property is still accessible by the calling code’
- [ ] ‘demonstrates that when the id is "introduced" by the macro the property is not accessible via the un-marked id’ fails for probably also because of the second problem described above too
- [ ] ‘Properties are attached to identifiers and not to bindings’ skipped because I don’t understand it (the spec document says they’re attached to bindings?) and Chibi doesn’t support internal aliases, see #802

The basic tests, above the ones by Jim Rees, (again suitably modified) should all pass, though.

But given how compromised this whole thing is, especially considering this is another change to the implementations of the core macro transformer constructors (to support `capture-lookup` as the spec intends), I’m not sure if merging would actually be a good idea.