### PR TITLE
allow user-specified CHIBI chibi-scheme path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ else()
     set(bootstrap chibi-scheme-bootstrap)
 endif()
 
-# when cross-compiling, we may nee
+# when cross-compiling, we need to use a separately built chibi-scheme executable:
 set(BOOTSTRAP ${bootstrap} CACHE FILEPATH "chibi-scheme path for bootstrapping")
 
 function(add_stubs_library stub)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ else()
 endif()
 
 # when cross-compiling, we need to use a separately built chibi-scheme executable:
-set(BOOTSTRAP ${bootstrap} CACHE FILEPATH "chibi-scheme path for bootstrapping")
+set(CHIBI ${bootstrap} CACHE FILEPATH "chibi-scheme path for bootstrapping")
 
 function(add_stubs_library stub)
     set(link-libraries LINK_LIBRARIES)
@@ -225,7 +225,7 @@ function(add_stubs_library stub)
     file(MAKE_DIRECTORY ${stubdir})
 
     add_custom_command(OUTPUT ${stubout}
-        COMMAND ${BOOTSTRAP} ${chibi-ffi} ${stubfile} ${stubout}
+        COMMAND ${CHIBI} ${chibi-ffi} ${stubfile} ${stubout}
         DEPENDS ${stubfile} ${chibi-ffi}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -384,12 +384,12 @@ set(chibi-scheme-tests
 
 foreach(e ${chibi-scheme-tests})
     add_test(NAME "${e}"
-        COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib tests/${e}.scm
+        COMMAND ${CHIBI} -I ${CMAKE_CURRENT_BINARY_DIR}/lib tests/${e}.scm
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
 add_test(NAME r5rs-test
-    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xchibi tests/r5rs-tests.scm
+    COMMAND ${CHIBI} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xchibi tests/r5rs-tests.scm
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 file(GLOB_RECURSE srfi_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/lib
@@ -429,7 +429,7 @@ foreach(e ${testlibs})
     string(REGEX REPLACE "/" "_" testname ${e})
     string(REGEX REPLACE "/" " " form ${e})
     add_test(NAME "lib_${testname}"
-        COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib
+        COMMAND ${CHIBI} -I ${CMAKE_CURRENT_BINARY_DIR}/lib
         -e "(import (${form}))"
         -e "(run-tests)"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
@@ -465,15 +465,15 @@ add_test(NAME "foreign-typeid"
 #
 
 add_custom_command(OUTPUT chibi.img
-    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -mchibi.repl
+    COMMAND ${CHIBI} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -mchibi.repl
     -d ${CMAKE_CURRENT_BINARY_DIR}/chibi.img
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_command(OUTPUT red.img
-    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xscheme.red -mchibi.repl
+    COMMAND ${CHIBI} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xscheme.red -mchibi.repl
     -d ${CMAKE_CURRENT_BINARY_DIR}/red.img
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_command(OUTPUT snow.img
-    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib
+    COMMAND ${CHIBI} -I ${CMAKE_CURRENT_BINARY_DIR}/lib
         -mchibi.snow.commands -mchibi.snow.interface -mchibi.snow.package -mchibi.snow.utils
         -d ${CMAKE_CURRENT_BINARY_DIR}/snow.img
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,9 @@ else()
     set(bootstrap chibi-scheme-bootstrap)
 endif()
 
+# when cross-compiling, we may nee
+set(BOOTSTRAP ${bootstrap} CACHE FILEPATH "chibi-scheme path for bootstrapping")
+
 function(add_stubs_library stub)
     set(link-libraries LINK_LIBRARIES)
     cmake_parse_arguments(stubs-options "" "" "${link-libraries}" ${ARGN})
@@ -222,7 +225,7 @@ function(add_stubs_library stub)
     file(MAKE_DIRECTORY ${stubdir})
 
     add_custom_command(OUTPUT ${stubout}
-        COMMAND ${bootstrap} ${chibi-ffi} ${stubfile} ${stubout}
+        COMMAND ${BOOTSTRAP} ${chibi-ffi} ${stubfile} ${stubout}
         DEPENDS ${stubfile} ${chibi-ffi}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,12 +384,12 @@ set(chibi-scheme-tests
 
 foreach(e ${chibi-scheme-tests})
     add_test(NAME "${e}"
-        COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib tests/${e}.scm
+        COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib tests/${e}.scm
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endforeach()
 
 add_test(NAME r5rs-test
-    COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xchibi tests/r5rs-tests.scm
+    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xchibi tests/r5rs-tests.scm
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 file(GLOB_RECURSE srfi_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/lib
@@ -429,7 +429,7 @@ foreach(e ${testlibs})
     string(REGEX REPLACE "/" "_" testname ${e})
     string(REGEX REPLACE "/" " " form ${e})
     add_test(NAME "lib_${testname}"
-        COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib
+        COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib
         -e "(import (${form}))"
         -e "(run-tests)"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
@@ -465,15 +465,15 @@ add_test(NAME "foreign-typeid"
 #
 
 add_custom_command(OUTPUT chibi.img
-    COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib -mchibi.repl
+    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -mchibi.repl
     -d ${CMAKE_CURRENT_BINARY_DIR}/chibi.img
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_command(OUTPUT red.img
-    COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xscheme.red -mchibi.repl
+    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib -xscheme.red -mchibi.repl
     -d ${CMAKE_CURRENT_BINARY_DIR}/red.img
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_custom_command(OUTPUT snow.img
-    COMMAND chibi-scheme -I ${CMAKE_CURRENT_BINARY_DIR}/lib
+    COMMAND ${BOOTSTRAP} -I ${CMAKE_CURRENT_BINARY_DIR}/lib
         -mchibi.snow.commands -mchibi.snow.interface -mchibi.snow.package -mchibi.snow.utils
         -d ${CMAKE_CURRENT_BINARY_DIR}/snow.img
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
I'm currently attempting to cross-compile chibi-scheme (https://github.com/JuliaPackaging/Yggdrasil/pull/4894), but in this situation you cannot use the built `chibi-scheme` executable (which is for the target architecture) to build image files, since the image-file creation runs on the host architecture.

To work around this, this PR allows you to `cmake -DCHIBI=...` to specify a path to `chibi-scheme` for bootstrapping (e.g. by first building on the host architecture as usual, and then starting another build to cross-compile).

PS. Any other advice about cross-compiling chibi-scheme would be welcome.  For example, are the image files portable between architectures or is there some special consideration when cross-compiling them?