### PR TITLE
Fix SEXP_CUSTOM_LONG_LONGS lsint_to_sint

### DIFF
--- a/include/chibi/bignum.h
+++ b/include/chibi/bignum.h
@@ -102,7 +102,7 @@ static inline sexp_luint_t luint_from_uint(sexp_uint_t v) {
 }
 
 static inline sexp_sint_t lsint_to_sint(sexp_lsint_t v) {
-  return lsint_lt_0(v) ? -v.lo : v.lo;
+  return v.lo;
 }
 
 static inline sexp_uint_t luint_to_uint(sexp_luint_t v) {
@@ -134,7 +134,7 @@ static inline sexp_lsint_t lsint_negate(sexp_lsint_t v) {
   uint64_t aLoHi = a.lo >> 32;
   uint64_t aHiLo = a.hi & 0xFFFFFFFF;
   uint64_t aHiHi = a.hi >> 32;
- 
+
   uint64_t carry;
   uint64_t sumLoLo = aLoLo + 1;
   carry = sumLoLo >> 32;
@@ -320,7 +320,7 @@ static inline sexp_luint_t luint_mul_uint(sexp_luint_t a, sexp_uint_t b) {
   }
 
   sexp_luint_t result = luint_add(resultBLo, luint_shl(resultBHi, 32));
-  
+
   return result;
 }
 


### PR DESCRIPTION
It looks like there's a bug in the custom 128-bit ints used in `bignum.h` when the 128-bit int gnu extension isn't available. When converting from 128-bit signed to 64-bit signed, it checks if the 128-bit value is negative and if so, erroneously negates the lower 64 bits. It should just return the lower bits as they are- this matches the behavior of when the gcc extension is present, ie casting an `__int128` to an `int64_t` 

---

Tested with
`sed -i '1s/^/#define SEXP_USE_CUSTOM_LONG_LONGS 1\n/' include/chibi/features.h && make -s && make test -s`

Against master (35eed621):
```
R7RS:
    4.1 Primitive expression types: ...........................
    27 out of 27 (100.0%) tests passed in 0.02413797378540039 seconds.
    4.2 Derived expression types: .............................................
     .............................
    74 out of 74 (100.0%) tests passed in 0.12354302406311035 seconds.
    4.3 Macros: .........................
    25 out of 25 (100.0%) tests passed in 0.08756494522094727 seconds.
    5 Program structure: ...............
    15 out of 15 (100.0%) tests passed in 0.030338048934936523 seconds.
    6.1 Equivalence Predicates: .........................
    25 out of 25 (100.0%) tests passed in 0.03513693809509277 seconds.
    6.2 Numbers: ..............................................................
     .....................................xx.....x.x...........................
     .............x.......................................................
    200 out of 205 (97.6%) tests passed in 0.20553994178771973 seconds.
    5 failures (2.4%).
    FAIL: (- 3/2)
        expected -3/2 but got 3/2
        on line 902 of file "tests/r7rs-tests.scm"
    FAIL: (- -3/2+i)
        expected -3/2-i but got 3/2-i
        on line 903 of file "tests/r7rs-tests.scm"
    FAIL: ...(floor/ -5 2)
        expected (-3 1) but got (-3 -11)
        on line 145 of file "lib/chibi/test.scm"
    FAIL: ...(floor/ -5 -2)
        expected (2 -1) but got (2 -9)
        on line 145 of file "lib/chibi/test.scm"
    FAIL: (rationalize (exact 0.3) 1/10)
        expected 1/3 but got 5/18428729675200063006
        on line 965 of file "tests/r7rs-tests.scm"
    6.3 Booleans: ..................
    18 out of 18 (100.0%) tests passed in 0.013541936874389648 seconds.
    6.4 Lists: ................................................................
     .
    65 out of 65 (100.0%) tests passed in 0.0809011459350586 seconds.
    6.5 Symbols: .................
    17 out of 17 (100.0%) tests passed in 0.02144312858581543 seconds.
    6.6 Characters: ...........................................................
     ....................
    79 out of 79 (100.0%) tests passed in 0.08081793785095215 seconds.
    6.7 Strings: ..............................................................
     ....................................................................
    130 out of 130 (100.0%) tests passed in 0.13984298706054688 seconds.
    6.8 Vectors: ...........................................
    43 out of 43 (100.0%) tests passed in 0.06325197219848633 seconds.
    6.9 Bytevectors: .......................................
    39 out of 39 (100.0%) tests passed in 0.04571795463562012 seconds.
    6.10 Control Features: ..................................
    34 out of 34 (100.0%) tests passed in 0.05918598175048828 seconds.
    6.11 Exceptions: ..............................
    30 out of 30 (100.0%) tests passed in 0.057805776596069336 seconds.
    6.12 Environments and evaluation: ....
    4 out of 4 (100.0%) tests passed in 0.00680994987487793 seconds.
    6.13 Input and output: ....................................................
     ...........
        Read syntax: ..........................................................
         ...................................
        93 out of 93 (100.0%) tests passed in 0.1105949878692627 seconds.
        Numeric syntax: .......................................................
         .....................x...........x...x.......x.x.x...x................
         ......................................................................
         .........................
        213 out of 220 (96.8%) tests passed in 0.35393500328063965 seconds.
        7 failures (3.2%).
        FAIL: (values z)
            expected 1/2 but got -1/2
            on line 2296 of file "tests/r7rs-tests.scm"
        FAIL: (values z)
            expected 1+2i but got 1-2i
            on line 2296 of file "tests/r7rs-tests.scm"
        FAIL: (values z)
            expected -1+2i but got -1-2i
            on line 2296 of file "tests/r7rs-tests.scm"
        FAIL: (values z)
            expected 0+i but got 0-i
            on line 2296 of file "tests/r7rs-tests.scm"
        FAIL: (values z)
            expected 0+i but got 0-i
            on line 2296 of file "tests/r7rs-tests.scm"
        FAIL: (values z)
            expected 0+i but got 0-i
            on line 2296 of file "tests/r7rs-tests.scm"
        FAIL: (values z)
            expected 0+2i but got 0-2i
            on line 2296 of file "tests/r7rs-tests.scm"
    369 out of 376 (98.1%) tests passed in 0.5640299320220947 seconds.
    7 failures (1.9%).
    1 out of 2 (50.0%) subgroup passed.
    6.14 System interface: .............
    13 out of 13 (100.0%) tests passed in 0.013155937194824219 seconds.
1207 out of 1219 (99.0%) tests passed in 1.6663498878479004 seconds.
12 failures (1.0%).
16 out of 18 (88.9%) subgroups passed.
```

Against this branch:
```
R7RS:
    4.1 Primitive expression types: ...........................
    27 out of 27 (100.0%) tests passed in 0.023981094360351562 seconds.
    4.2 Derived expression types: .............................................
     .............................
    74 out of 74 (100.0%) tests passed in 0.12123513221740723 seconds.
    4.3 Macros: .........................
    25 out of 25 (100.0%) tests passed in 0.08048200607299805 seconds.
    5 Program structure: ...............
    15 out of 15 (100.0%) tests passed in 0.034173011779785156 seconds.
    6.1 Equivalence Predicates: .........................
    25 out of 25 (100.0%) tests passed in 0.03249096870422363 seconds.
    6.2 Numbers: ..............................................................
     ..........................................................................
     .....................................................................
    205 out of 205 (100.0%) tests passed in 0.20270395278930664 seconds.
    6.3 Booleans: ..................
    18 out of 18 (100.0%) tests passed in 0.02454686164855957 seconds.
    6.4 Lists: ................................................................
     .
    65 out of 65 (100.0%) tests passed in 0.09040307998657227 seconds.
    6.5 Symbols: .................
    17 out of 17 (100.0%) tests passed in 0.01741313934326172 seconds.
    6.6 Characters: ...........................................................
     ....................
    79 out of 79 (100.0%) tests passed in 0.07916116714477539 seconds.
    6.7 Strings: ..............................................................
     ....................................................................
    130 out of 130 (100.0%) tests passed in 0.14061188697814941 seconds.
    6.8 Vectors: ...........................................
    43 out of 43 (100.0%) tests passed in 0.055779218673706055 seconds.
    6.9 Bytevectors: .......................................
    39 out of 39 (100.0%) tests passed in 0.0433349609375 seconds.
    6.10 Control Features: ..................................
    34 out of 34 (100.0%) tests passed in 0.06687283515930176 seconds.
    6.11 Exceptions: ..............................
    30 out of 30 (100.0%) tests passed in 0.05129194259643555 seconds.
    6.12 Environments and evaluation: ....
    4 out of 4 (100.0%) tests passed in 0.008047103881835938 seconds.
    6.13 Input and output: ....................................................
     ...........
        Read syntax: ..........................................................
         ...................................
        93 out of 93 (100.0%) tests passed in 0.0997319221496582 seconds.
        Numeric syntax: .......................................................
         ......................................................................
         ......................................................................
         .........................
        220 out of 220 (100.0%) tests passed in 0.3776581287384033 seconds.
    376 out of 376 (100.0%) tests passed in 0.564967155456543 seconds.
    2 out of 2 (100.0%) subgroups passed.
    6.14 System interface: .............
    13 out of 13 (100.0%) tests passed in 0.014436960220336914 seconds.
1219 out of 1219 (100.0%) tests passed in 1.6551690101623535 seconds.
18 out of 18 (100.0%) subgroups passed.
```