### PR TITLE
Add (chibi shell) to the documentation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ MODULE_DOCS := app assert ast base64 bytevector config crypto/md5 crypto/rsa \
 	match math/prime memoize mime modules net net/http-server net/servlet \
 	optional parse pathname process repl scribble string stty sxml system \
 	temp-file test time trace type-inference uri weak monad/environment \
-	crypto/sha2
+	crypto/sha2 shell
 
 IMAGE_FILES = lib/chibi.img lib/red.img lib/snow.img
 

--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -1374,6 +1374,8 @@ namespace.
 
 \item{\hyperlink["lib/chibi/repl.html"]{(chibi repl) - A full-featured Read/Eval/Print Loop}}
 
+\item{\hyperlink["lib/chibi/shell.html"]{(chibi shell) - Binding to the most necessary POSIX system calls.}}
+
 \item{\hyperlink["lib/chibi/scribble.html"]{(chibi scribble) - A parser for the scribble syntax used to write this manual}}
 
 \item{\hyperlink["lib/chibi/string.html"]{(chibi string) - Cursor-based string library (predecessor to SRFI 130)}}


### PR DESCRIPTION
1. Add "shell" to the list of html_docs
2. Add a reference to (chibi shell) to chibi.scribl

I would like to also ask to regenerate the docs at http://synthcode.com/scheme/chibi/
(Perhaps it would not be too much of a burden to move the manual to Github Pages? Then the manual can be automatically regenerated on every push.)