### PR TITLE
Make (shell) in (chibi shell) return exit status of last command.

### DIFF
--- a/lib/chibi/shell.scm
+++ b/lib/chibi/shell.scm
@@ -494,10 +494,11 @@
       (lambda () #f)
       (lambda () #f)))))
 
+;;> Returns the exit status of the last command in the pipeline.
 (define-syntax shell
   (syntax-rules ()
     ((shell cmd ...)
-     (for-each shell-wait (shell& cmd ...)))))
+     (map shell-wait (shell& cmd ...)))))
 
 (define-syntax shell->string
   (syntax-rules ()


### PR DESCRIPTION
Should fix https://github.com/ashinn/chibi-scheme/issues/851

Not sure if this is the best possible way of working with exit statuses, but exit statuses are useful, so maybe at least temporarily use this solution?

