### PR TITLE
Add support for exporting statically compiled libraries from C

### DIFF
--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -23,15 +23,26 @@
 /*   sexp_init_library(ctx, env) function provided. */
 /* #define SEXP_USE_DL 0 */
 
-/* uncomment this to statically compile all C libs */
-/*   If set, this will statically include the clibs.c file */
-/*   into the standard environment, so that you can have */
-/*   access to a predefined set of C libraries without */
-/*   needing dynamic loading.  The clibs.c file is generated */
-/*   automatically by searching the lib directory for */
-/*   modules with include-shared, but can be hand-tailored */
-/*   to your needs. */
+/* uncomment this to support statically compiled C libs */
+/*   Unless SEXP_USE_STATIC_LIBS_EMPTY is set (see below), this */
+/*   will statically include the clibs.c file into the standard */
+/*   environment, so that you can have access to a predefined set */
+/*   of C libraries without needing dynamic loading.  The clibs.c */
+/*   file is generated automatically by searching the lib directory */
+/*   for modules with include-shared, but can be hand-tailored to */
+/*   your needs.  You can also register your own C libraries using */
+/*   sexp_add_static_libraries (see below). */
 /* #define SEXP_USE_STATIC_LIBS 1 */
+
+/* uncomment this to enable user exported C libs */
+/*   You can register your own C libraries using */
+/*   sexp_add_static_libraries.  Each entry in the supplied table, */
+/*   is a name/entry point pair.  These work as if they were */
+/*   dynamically loaded libraries, so naming follows the same */
+/*   conventions.  An entry {"foo", init_foo} will register a */
+/*   library that can be loaded with (load "foo"), or */
+/*   (include-shared "foo"), both of which will call init_foo. */
+/* #define SEXP_USE_STATIC_LIBS_EMPTY 1 */
 
 /* uncomment this to disable detailed source info for debugging */
 /*   By default Chibi will associate source info with every */
@@ -461,13 +472,17 @@
 #endif
 #endif
 
+#ifndef SEXP_USE_STATIC_LIBS_EMPTY
+#define SEXP_USE_STATIC_LIBS_EMPTY 0
+#endif
+
 #ifndef SEXP_USE_STATIC_LIBS
-#define SEXP_USE_STATIC_LIBS 0
+#define SEXP_USE_STATIC_LIBS SEXP_USE_STATIC_LIBS_EMPTY
 #endif
 
 /* don't include clibs.c - include separately or link */
 #ifndef SEXP_USE_STATIC_LIBS_NO_INCLUDE
-#ifdef PLAN9
+#if defined(PLAN9) || SEXP_USE_STATIC_LIBS_EMPTY
 #define SEXP_USE_STATIC_LIBS_NO_INCLUDE 0
 #else
 #define SEXP_USE_STATIC_LIBS_NO_INCLUDE 1

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -395,8 +395,8 @@ struct sexp_gc_var_t {
   struct sexp_gc_var_t *next;
 };
 
-struct sexp_library_entry_t {   /* for static builds */
-  const char *name;
+struct sexp_library_entry_t {   /* for static builds and user exported C */
+  const char *name;             /* libaries */
   sexp_init_proc init;
 };
 
@@ -1679,6 +1679,16 @@ sexp sexp_finalize_dl (sexp ctx, sexp self, sexp_sint_t n, sexp dl);
 #else
 #define sexp_current_source_param
 #endif
+
+/* To export a library from the embedding C program to Scheme, so    */
+/* that it can be included into Scheme library foo/qux.sld as        */
+/* (include-shared "bar"), libraries should contain the entry        */
+/* {"foo/bar", init_bar}.  The signature and function of init_bar is */
+/* the same as that of sexp_init_library in shared libraries.  The   */
+/* array libraries must be terminated with {NULL, NULL} and must     */
+/* remain valid throughout its use by Chibi.                         */
+
+SEXP_API void sexp_add_static_libraries(struct sexp_library_entry_t* libraries);
 
 SEXP_API sexp sexp_alloc_tagged_aux(sexp ctx, size_t size, sexp_uint_t tag sexp_current_source_param);
 SEXP_API sexp sexp_make_context(sexp ctx, size_t size, size_t max_size);


### PR DESCRIPTION
This PR trivially extends the existing mechanism for statically compiled libraries to allow the user to export custom libraries from C.  I currently use it to export a relatively complex API from the C side as an importable library in scheme (mainly for the benefit of allowing organization into sublibraries, selective import of symbols, renaming symbols, etc.)  Use goes something like this:

From the C side:

```C
#include <chibi/sexp.h>
#include <chibi/install.h>

static sexp test(sexp ctx, sexp self, sexp_sint_t n, sexp arg)
{
    return arg;
}

sexp init_foo(
    sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version,
    const sexp_abi_identifier_t abi) {
    sexp_define_foreign(ctx, env, "test", 1, test);
    return SEXP_VOID;
}

static struct sexp_library_entry_t sexp_static_libraries_array[] = {
    {"foo/foo" sexp_so_extension, init_foo},
    {nullptr, nullptr}
};

extern struct sexp_library_entry_t *sexp_static_libraries;
```
Then somewhere in the initialization function for chibi-scheme, I add:

```C
sexp_static_libraries = sexp_static_libraries_array;
```

Then from Scheme, somewhere in, say `./foo/bar.sld`:

```scheme
(define-library (foo bar)
  (export test)
  (include-shared "foo"))
```

Then in the main program one can:

```scheme
(import (scheme write) (foo bar))

(display (test "foo"))
(newline)
```

As it is, the design is quite elementary and doesn't make any attempt to cover up its co-opting of the statically included shared library mechanism.  As such, the user is forced to bother with mimicking shared library import paths and extensions.  This is not a big bother really and it is usable just fine as is, but if you prefer, we could look into further streamlining the interface.

Edit: This started off leaving the the `sexp_static_libraries` symbol undefined and simply defining it in the main program.  This turned out not to be supported on Windows though.  I then tried initializing `sexp_static_libraries` to an empty table, but marking it `__attribute__((weak)))`, but this doesn't work on MSVC.  This third attempt also fails in some cases, although I'm not sure why.  I'll look further into it, but if you have any comments, let me know.