### PR TITLE
Fix bug: attributes without values didn't work.

### DIFF
--- a/lib/chibi/sxml.scm
+++ b/lib/chibi/sxml.scm
@@ -40,11 +40,11 @@
     (lambda (out) (html-display-escaped-attr (display-to-string str) out))))
 
 (define (html-attr->string attr)
-  (if (cdr attr)
+  (if (null? (cdr attr))
+      (symbol->string (car attr))
       (let ((val (if (pair? (cdr attr)) (cadr attr) (cdr attr))))
         (string-append (symbol->string (car attr))
-                       "=\"" (html-escape-attr val) "\""))
-      (symbol->string (car attr))))
+                       "=\"" (html-escape-attr val) "\""))))
 
 (define (html-tag->string tag attrs)
   (let lp ((ls attrs) (res (list (symbol->string tag) "<")))


### PR DESCRIPTION
Before, it was necessary to do something like this:

  (option (@ (selected . #false) (value "any")) "any")

instead of:

  (option (@ (selected) (value "any")) "any")

Only the former is valid SXML, as far as I can tell from the SXML specification:

  <https://dl.acm.org/doi/pdf/10.1145/571727.571736>