### PR TITLE
Make macro-aux safe for other things together with syntax-case

### DIFF
--- a/lib/chibi/syntax-case.sld
+++ b/lib/chibi/syntax-case.sld
@@ -16,6 +16,8 @@
                 make-variable-transformer)
           (only (meta) environment)
           (srfi 1)
+          (srfi 2)
+          (srfi 9)
           (srfi 11)
           (srfi 39))
   (include "syntax-case.scm"))


### PR DESCRIPTION
If you set the macro-aux of a macro outside of (chibi syntax-case), it would previously case `syntax` to think that it was a pattern variable and try to substitute it, even if the macro-aux was being used for something else.

This patch fixes that by wrapping pattern variable values in an extra typed box and checking that it has the right type before deciding that it’s actually a pattern variable.