### PR TITLE
Fix syntax-tests to use mutable-environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,13 +269,16 @@ test-r5rs: chibi-scheme$(EXE)
 test-r7rs: chibi-scheme$(EXE)
 	$(CHIBI) tests/r7rs-tests.scm
 
+test-syntax: chibi-scheme$(EXE)
+	$(CHIBI) tests/syntax-tests.scm
+
 test: test-r7rs
 
 test-safe-string-cursors: chibi-scheme$(EXE)
 	$(CHIBI) -Dsafe-string-cursors tests/r7rs-tests.scm
 	$(CHIBI) -Dsafe-string-cursors tests/lib-tests.scm
 
-test-all: test test-libs test-ffi test-division
+test-all: test test-syntax test-libs test-ffi test-division
 
 test-dist: test-all test-memory test-build
 

--- a/tests/syntax-tests.scm
+++ b/tests/syntax-tests.scm
@@ -3,7 +3,7 @@
  (modules
   (import (chibi)
           (only (chibi test) test-begin test test-error test-end)
-          (only (meta) environment)))
+          (only (meta) mutable-environment)))
  (else #f))
 
 (test-begin "syntax")
@@ -84,7 +84,7 @@
  ;; this could be fixed in theory)
  (modules
   (test-begin "identifier syntax")
-  (define syntax-test-env (environment '(chibi) '(chibi ast)))
+  (define syntax-test-env (mutable-environment '(chibi) '(chibi ast)))
 
   (eval
    '(define-syntax low-level-id-macro


### PR DESCRIPTION
The AppVeyor cmake build was failing because the identifier syntax tests used `environment` assuming its result was mutable; this broke as of 0eeeac765093a55234cbd1fdd2e04d6f20ff1027.

This patch also adds the syntax-tests to the `test-all` suite, so similar regressions in future will be caught by all the CI builds failing, not just the AppVeyor one.