### PR TITLE
add support for Guile [snow-chibi]

### DIFF
--- a/lib/chibi/snow/utils.scm
+++ b/lib/chibi/snow/utils.scm
@@ -29,6 +29,10 @@
             ,(delay
                (process->sexp
                 '(gosh -uscheme.base -e "(write (features))"))))
+    (guile "guile" (guile -e "(display (version))") "3.0.8"
+           ,(delay
+              (process->sexp
+               '(guile --r7rs -c "(import (scheme base)) (display (features))"))))
     (kawa "kawa" (kawa --version) "2.0"
           ,(delay
              (process->sexp


### PR DESCRIPTION
Two recent changes to Guile improved its R7RS support:

- 3.0.7 fixed a bug regarding cond-expand in a define-library form.
- 3.0.8 added support for R7RS' srfi library names, e.g. (srfi 69) instead of (srfi srfi-69) used by Guile.

These changes open the possibility for using snow libraries in R7RS Guile programs. This commit adds support for installing/removing snow libraries for Guile.