### PR TITLE
Drop (chibi sxml) dependency on let-optionals

### DIFF
--- a/lib/chibi/sxml.scm
+++ b/lib/chibi/sxml.scm
@@ -91,9 +91,12 @@
 
 ;;> Render (valid, expanded) \var{sxml} as html.
 ;;> \var{@raw} tag is considered safe text and not processed or escaped.
-(define (sxml-display-as-html sxml . o)
-  (let-optionals o ((out (current-output-port))
-		    (indent? #false))
+(define (sxml-display-as-html sxml . args)
+  (let* ((out (if (null? args) (current-output-port) (car args)))
+         (args (if (null? args) args (cdr args)))
+	 (indent? (if (null? args) #f (car args)))
+         (args (if (null? args) args (cdr args))))
+    (unless (null? args) (error "too many args"))
     (let lp ((sxml (if (and (pair? sxml) (eq? '*TOP* (car sxml)))
                        (cdr sxml)
                        sxml))

--- a/lib/chibi/sxml.sld
+++ b/lib/chibi/sxml.sld
@@ -4,5 +4,5 @@
 (define-library (chibi sxml)
   (export sxml->xml sxml-display-as-html sxml-display-as-text sxml-strip
           html-escape html-tag->string)
-  (import (chibi optional) (scheme base) (scheme write))
+  (import (scheme base) (scheme write))
   (include "sxml.scm"))


### PR DESCRIPTION
let-optionals can be provided by the (chibi optional) library or by SRFI 227. Either dependency is non-trivial and makes it tricky to incorporate (chibi sxml) into outside projects. Since (chibi sxml) only makes trivial use of let-optionals, expand the macro by hand.