### PR TITLE
Handle basic special characters in `write`

### DIFF
--- a/lib/srfi/38.scm
+++ b/lib/srfi/38.scm
@@ -3,6 +3,17 @@
 ;; This code was written by Alex Shinn in 2009 and placed in the
 ;; Public Domain.  All warranties are disclaimed.
 
+(define escaped-chars
+  '((#\alarm . "alarm")
+    (#\backspace . "backspace")
+    (#\delete . "delete")
+    (#\escape . "escape")
+    (#\newline . "newline")
+    (#\null . "null")
+    (#\return . "return")
+    (#\space . "space")
+    (#\tab . "tab")))
+
 (define (raise-typed-error type)
   (lambda (msg . args) (raise (make-exception type msg args #f #f))))
 (define read-error (raise-typed-error 'read))
@@ -111,7 +122,12 @@
             (and (type? type) (type-printer type)))
           => (lambda (printer) (printer x wr out)))
          ((null? x) (display "()" out))
-         ((char? x) (display "#\\" out) (write-char x out))
+         ((char? x)
+          (display "#\\" out)
+          (let ((pair (assv x escaped-chars)))
+            (if pair
+              (display (cdr pair) out)
+              (write-char x out))))
          ((symbol? x) (write x out))
          ((number? x) (display (number->string x) out))
          ((eq? x #t) (display "#t" out))

--- a/lib/srfi/38/test.sld
+++ b/lib/srfi/38/test.sld
@@ -80,7 +80,7 @@
                  (vector-set! x 2 x)
                  x))
 
-      (test "#\newline" #\newline)
+      (test-io "#\\newline" #\newline)
 
       (test '+.! (read-from-string "+.!"))
 

--- a/lib/srfi/38/test.sld
+++ b/lib/srfi/38/test.sld
@@ -80,6 +80,8 @@
                  (vector-set! x 2 x)
                  x))
 
+      (test "#\newline" #\newline)
+
       (test '+.! (read-from-string "+.!"))
 
       (test 255 (read-from-string "#xff"))


### PR DESCRIPTION
This PR fixes the implementation of `write` in SRFI 38 with special characters (e.g. newline and tab) as described in the section "6.13.3. Output" in the [R7RS](https://small.r7rs.org/attachment/r7rs.pdf).