### PR TITLE
Unwind on exit

### DIFF
--- a/lib/chibi/process.scm
+++ b/lib/chibi/process.scm
@@ -1,19 +1,28 @@
+(define unwind #f)
+
+((call/cc
+    (lambda (k)
+      (set! unwind k)
+      (lambda () #f))))
 
 (cond-expand
  (plan9
-  (define (exit . o)
+  (define (emergency-exit . o)
     (%exit (if (pair? o)
                (if (string? (car o))
                    (car o)
                    (if (eq? #t (car o)) "" "chibi error"))
                ""))))
  (else
-  (define (exit . o)
+  (define (emergency-exit . o)
     (%exit (if (pair? o)
                (if (integer? (car o))
                    (inexact->exact (car o))
                    (if (eq? #t (car o)) 0 1))
                0)))))
+
+(define (exit . o)
+  (unwind (lambda () (apply emergency-exit o))))
 
 (cond-expand
  (bsd

--- a/lib/chibi/process.sld
+++ b/lib/chibi/process.sld
@@ -18,7 +18,7 @@
           call-with-process-io process->bytevector
           process->string process->sexp process->string-list
           process->output+error process->output+error+status)
-  (import (chibi) (chibi io) (chibi string) (chibi filesystem))
+  (import (chibi) (chibi io) (chibi string) (chibi filesystem) (only (scheme base) call/cc))
   (cond-expand (threads (import (srfi 18) (srfi 151))) (else #f))
   (cond-expand ((not windows) (include-shared "process")))
   (include "process.scm"))

--- a/lib/chibi/process.sld
+++ b/lib/chibi/process.sld
@@ -1,7 +1,8 @@
 
 (define-library (chibi process)
-  (export exit sleep alarm %fork fork kill execute waitpid system system?
-          process-command-line  process-running?
+  (export exit emergency-exit sleep alarm
+          %fork fork kill execute waitpid system system?
+          process-command-line process-running?
           set-signal-action! make-signal-set
           signal-set? signal-set-contains?
           signal-set-fill! signal-set-add! signal-set-delete!

--- a/lib/chibi/win32/process-win32.scm
+++ b/lib/chibi/win32/process-win32.scm
@@ -1,7 +1,17 @@
-(define (exit . code?)
+(define unwind #f)
+
+((call/cc
+    (lambda (k)
+      (set! unwind k)
+      (lambda () #f))))
+
+(define (emergency-exit . code?)
   (%exit (if (pair? code?) 
            (let ((c (car code?)))
             (cond ((integer? c) c)
                   ((eq? #t c) 0)
                   (else 1)))
            0)))
+
+(define (exit . o)
+  (unwind (lambda () (apply emergency-exit o))))

--- a/lib/chibi/win32/process-win32.sld
+++ b/lib/chibi/win32/process-win32.sld
@@ -1,9 +1,9 @@
 (define-library (chibi win32 process-win32)
   (import (scheme base))
-  (export exit)
+  (export exit emergency-exit)
   (cond-expand
    (windows
     (include-shared "process-win32")
     (include "process-win32.scm"))
    (else
-    (import (only (chibi process) exit)))))
+    (import (only (chibi process) exit emergency-exit)))))

--- a/lib/scheme/process-context.sld
+++ b/lib/scheme/process-context.sld
@@ -1,18 +1,20 @@
 
 (define-library (scheme process-context)
-  (import (chibi) (srfi 98))
-  (cond-expand (windows (import (rename (only (chibi win32 process-win32) exit) (exit emergency-exit))))
-               (else (import (rename (only (chibi process) exit) (exit emergency-exit)))))
+  (import (chibi) (only (scheme base) call/cc) (srfi 98))
+  (cond-expand (windows (import (rename (chibi win32 process-win32) (exit emergency-exit))))
+               (else (import (prefix (chibi process) process-))))
   (export get-environment-variable get-environment-variables
           command-line exit emergency-exit)
 
-  (begin 
+  (begin
     (define unwind #f)
 
     ((call/cc
-        (lambda (continuation)
-          (set! unwind continuation)
+        (lambda (cont)
+          (set! unwind cont)
           (lambda () #f))))
+
+    (define emergency-exit process-exit)
 
     (define (exit . rest)
       (unwind (lambda () (apply emergency-exit rest))))))

--- a/lib/scheme/process-context.sld
+++ b/lib/scheme/process-context.sld
@@ -1,20 +1,7 @@
 
 (define-library (scheme process-context)
-  (import (chibi) (only (scheme base) call/cc) (srfi 98))
-  (cond-expand (windows (import (prefix (only (chibi win32 process-win32) exit) process-)))
-               (else (import (prefix (only (chibi process) exit) process-))))
+  (import (chibi) (srfi 98))
+  (cond-expand (windows (import (only (chibi win32 process-win32) exit emergency-exit)))
+               (else (import (only (chibi process) exit emergency-exit))))
   (export get-environment-variable get-environment-variables
-          command-line exit emergency-exit)
-
-  (begin
-    (define unwind #f)
-
-    ((call/cc
-        (lambda (cont)
-          (set! unwind cont)
-          (lambda () #f))))
-
-    (define emergency-exit process-exit)
-
-    (define (exit . rest)
-      (unwind (lambda () (apply emergency-exit rest))))))
+          command-line exit emergency-exit))

--- a/lib/scheme/process-context.sld
+++ b/lib/scheme/process-context.sld
@@ -1,8 +1,8 @@
 
 (define-library (scheme process-context)
   (import (chibi) (only (scheme base) call/cc) (srfi 98))
-  (cond-expand (windows (import (rename (chibi win32 process-win32) (exit emergency-exit))))
-               (else (import (prefix (chibi process) process-))))
+  (cond-expand (windows (import (prefix (only (chibi win32 process-win32) exit) process-)))
+               (else (import (prefix (only (chibi process) exit) process-))))
   (export get-environment-variable get-environment-variables
           command-line exit emergency-exit)
 

--- a/lib/scheme/process-context.sld
+++ b/lib/scheme/process-context.sld
@@ -1,9 +1,18 @@
 
 (define-library (scheme process-context)
   (import (chibi) (srfi 98))
-  (cond-expand (windows (import (only (chibi win32 process-win32) exit)))
-               (else (import (only (chibi process) exit))))
+  (cond-expand (windows (import (rename (only (chibi win32 process-win32) exit) (exit emergency-exit))))
+               (else (import (rename (only (chibi process) exit) (exit emergency-exit)))))
   (export get-environment-variable get-environment-variables
           command-line exit emergency-exit)
-  ;; TODO: Make exit unwind and finalize properly.
-  (begin (define emergency-exit exit)))
+
+  (begin 
+    (define unwind #f)
+
+    ((call/cc
+        (lambda (continuation)
+          (set! unwind continuation)
+          (lambda () #f))))
+
+    (define (exit . rest)
+      (unwind (lambda () (apply emergency-exit rest))))))


### PR DESCRIPTION
# Description

This PR implements the unwinding of dynamic extents on a call to the `exit` procedure as described in "6.14. System interface" in [the R7RS specification](https://small.r7rs.org/attachment/r7rs.pdf) using `call/cc`.

# Questions

- [ ] Where can I write tests for the new behaviour with side effects of `exit`?
- [x] When I build the library, it emits those warnings. But I don't know why it happens while I'm still using the `only` predicate in imports.
 
```sh
> make install
...
if type ldconfig >/dev/null 2>/dev/null; then ldconfig; fi
echo "Generating images"
Generating images
[ -z "" ] && LD_LIBRARY_PATH="local/lib:" DYLD_LIBRARY_PATH="local/lib:" CHIBI_MODULE_PATH="local/share/chibi:local/lib/chibi" local/bin/chibi-scheme -mchibi.repl -d local/share/chibi/chibi.img
[ -z "" ] && LD_LIBRARY_PATH="local/lib:" DYLD_LIBRARY_PATH="local/lib:" CHIBI_MODULE_PATH="local/share/chibi:local/lib/chibi" local/bin/chibi-scheme -xscheme.red -mchibi.repl -d local/share/chibi/red.img
[ -z "" ] && LD_LIBRARY_PATH="local/lib:" DYLD_LIBRARY_PATH="local/lib:" CHIBI_MODULE_PATH="local/share/chibi:local/lib/chibi" local/bin/chibi-scheme -mchibi.snow.commands -mchibi.snow.interface -mchibi.snow.package -mchibi.snow.utils -d local/share/chibi/snow.img
WARNING: importing already defined binding: exit
WARNING: importing already defined binding: exit
```

Thanks ahead!