### PR TITLE
Fix SEXP_USE_ALIGNED_BYTECODE

### DIFF
--- a/include/chibi/features.h
+++ b/include/chibi/features.h
@@ -301,7 +301,7 @@
 
 /* uncomment this to make the VM adhere to alignment rules */
 /*   This is required on some platforms, e.g. ARM */
-/* #define SEXP_USE_ALIGNED_BYTECODE */
+/* #define SEXP_USE_ALIGNED_BYTECODE 1 */
 
 /************************************************************************/
 /* These settings are configurable but only recommended for */


### PR DESCRIPTION
There were some typos that weren't affecting default compilation but causing immediate errors with the option enabled.