### PR TITLE
README: add link to online manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,5 @@ shared libraries.
 To make the emscripten build run `make js` (_not_ `emmake make js`).
 
 For more detailed documentation, run `make doc` and see the generated
-*doc/chibi.html*.
+*doc/chibi.html* or read the [manual](http://synthcode.com/scheme/chibi/)
+online.


### PR DESCRIPTION
It is not uncommon that the git repo is the first encounter with a project. Having the manual available in the repo makes it easier to discover.