### PR TITLE
Allow customizing which exception types are show-stopping

### DIFF
--- a/lib/srfi/35/internal.scm
+++ b/lib/srfi/35/internal.scm
@@ -204,6 +204,9 @@
 (define-condition-type/constructor &error &serious
   make-error error?)
 
+(register-non-serious-exception-predicate! condition?)
+(register-serious-exception-predicate! serious-condition?)
+
 ;; (chibi repl) support
 (define-method (repl-print-exception (exn condition?) (out output-port?))
   (define components (simple-conditions exn))

--- a/lib/srfi/35/internal.sld
+++ b/lib/srfi/35/internal.sld
@@ -6,7 +6,9 @@
           (scheme write)
           (only (chibi)
                 slot-ref
-                is-a?)
+                is-a?
+                register-non-serious-exception-predicate!
+                register-serious-exception-predicate!)
           (only (chibi repl) repl-print-exception)
           (only (chibi generic) define-method)
           ;; don’t let people go messing with a compound condition


### PR DESCRIPTION
What do you think of this as a solution to the issue raised in #1008 about some condition types, when raised continuably, returning control to the program?

This isn’t wired into the `(chibi repl)` exception handler yet as I wanted to get your feedback on this approach first.