### PR TITLE
add snow-chibi default configuration file instructions

### DIFF
--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -1446,17 +1446,11 @@ with image files on your platform you can run
 
 \subsection{Snow Configuration}
 
-Snow is configured in the file $HOME/.snow/config.scm, requiring at the
-bare minimum an empty alist:
-\schemeblock{
-()
-;; (()) would also work
-}
-
-Note that the empty list is \emph{not} quoted! This file is not evaluated,
-but is simply read as an alist of configurations. A more common example,
-for use with packaging your own code, may look like this:
-
+Snow is configured in the file $HOME/.snow/config.scm. A common example,
+for use with packaging your own code, may look like the one below:
+(Note that the empty list is \emph{not} quoted! This file is not evaluated,
+but is simply read as an alist of configurations. See
+https://snow-fort.org/doc/author/ for more details.)
 \schemeblock{
 ((authors "Alysssa P. Hacker <aphacker@mit.edu>")
  (maintainers "Alyssa P. Hacker <aphacker@mit.edu>, Eva Luator <eluator@mit.edu")

--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -1444,6 +1444,26 @@ loading (since it loads many libraries) - if you have any difficulties
 with image files on your platform you can run
 \command{snow-chibi --noimage} to disable this feature.
 
+\subsection{Snow Configuration}
+
+Snow is configured in the file $HOME/.snow/config.scm, requiring at the
+bare minimum an empty alist:
+\schemeblock{
+()
+;; (()) would also work
+}
+
+Note that the empty list is \emph{not} quoted! This file is not evaluated,
+but is simply read as an alist of configurations. A more common example,
+for use with packaging your own code, may look like this:
+
+\schemeblock{
+((authors "Alysssa P. Hacker <aphacker@mit.edu>")
+ (maintainers "Alyssa P. Hacker <aphacker@mit.edu>, Eva Luator <eluator@mit.edu")
+ (license agpl)) ;; or gpl mit bsd etc.
+}
+
+
 \subsubsection{Querying Packages and Status}
 
 By default \scheme{snow-chibi} looks for packages in the public


### PR DESCRIPTION
When running snow-chibi it errored out saying it needed a configuration file at `~/.snow/config.scm`, but it took a little trial and error to figure out both the minimum and my packaging use cases. Figured it might help others use it in the future!