### PR TITLE
Fix propably misplaced parenthesis on get-install-dirs with chicken

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1361,7 +1361,8 @@
        (list
         (if (file-exists? dir)  ; repository-path should always exist
             dir
-            (make-path (or (conf-get cfg 'install-prefix)) "lib" impl
+            (make-path (or (conf-get cfg 'install-prefix) "lib")
+                       impl
                        (get-chicken-binary-version cfg))))))
     ((cyclone)
      (let ((dir (let ((lib-path (get-environment-variable "CYCLONE_LIBRARY_PATH")))


### PR DESCRIPTION
If chicken is not installed then make-path on this line complains that #f is not valid input. I'm assuming this is what the code originally intended to do? Use install-prefix if it set, otherwise use "lib".