### PR TITLE
chibi-ffi: Move the cflags to the end of compiling arguments

### DIFF
--- a/tools/chibi-ffi
+++ b/tools/chibi-ffi
@@ -2439,8 +2439,8 @@
                  (execute (begin (eval '(import (chibi process))
                                        (current-environment))
                                  (eval 'execute (current-environment))))
-                 (base-args (append cflags *cflags*
-                                    `("-o" ,so ,dest "-lchibi-scheme")
+                 (base-args (append `("-o" ,so ,dest "-lchibi-scheme")
+                                    cflags *cflags*
                                     (map (lambda (x) (string-append "-l" x))
                                          (reverse *clibs*))
                                     (apply append


### PR DESCRIPTION
I mentioned what I think is a bug in here https://github.com/ashinn/chibi-scheme/pull/1029

"Fix possible library install compilation bug

While packaging and installing my library I think I run into a bug. In commands.scm chibi-builder procedure if .stub file exists then chibi-ffi is run with options to also try to compile the library. This puts the -lffi flag on compilation command not at the end with -lchibi-scheme but at the beginning and the resulted .so file can not be loaded due to missing linkin to libffi."

/tmp/lol.stub(just nonsense to showcase the linking):
```
(c-system-include "stdint.h")
(c-system-include "ffi.h")

(c-declare "int size_of_uint8_t() { return sizeof(uint8_t); }")
(c-declare "ffi_cif cif;")
(define-c-const int (FFI-OK "FFI_OK"))

(c-declare
  "void* internal_ffi_call(
      unsigned int nargs,
      unsigned int rtype,
      unsigned int atypes[],
      void* fn,
      unsigned int rvalue_size,
      struct sexp_struct* avalues[])
    {
    ffi_type* c_atypes[nargs];
    void* c_avalues[nargs];

    ffi_type* c_rtype = &ffi_type_void;
    int r = ffi_prep_cif(&cif, FFI_DEFAULT_ABI, nargs, c_rtype, c_atypes);

    void* rvalue = malloc(42);
    ffi_call(&cif, FFI_FN(fn), rvalue, c_avalues);
    return rvalue;
  }")

```
So the output from
`chibi-ffi -c -f -lffi /tmp/lol.stub`

Was:
`;; ("cc" "-fPIC" "-shared" "-Os" "-lffi" "-o" "/tmp/lol.so" "/tmp/lol.c" "-lchibi-scheme")`
and ldd /tmp/lol.so:
```
        linux-vdso.so.1 (0x00007f2be2ddd000)
        libchibi-scheme.so.0 => /usr/local/lib/libchibi-scheme.so.0 (0x00007f2be2d73000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2be2b7d000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f2be2a8d000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2be2ddf000)
```

after the change:
`;; ("cc" "-fPIC" "-shared" "-Os" "-o" "/tmp/lol.so" "/tmp/lol.c" "-lchibi-scheme" "-lffi")`
and ldd /tmp/lol.so:
```
        linux-vdso.so.1 (0x00007f5c89f7c000)
        libchibi-scheme.so.0 => /usr/local/lib/libchibi-scheme.so.0 (0x00007f5c89f12000)
        libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8 (0x00007f5c89f05000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5c89d0f000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f5c89c1f000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f5c89f7e000)
```

I'm not a C expert so could this make other cflags not work? Should the cflags and library flags have their own flags like -f and -l?