### PR TITLE
snow-chibi Kawa improvements

### DIFF
--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -1664,7 +1664,7 @@ installed. The following are currently supported:
 \item{gambit - version >= 4.9.3}
 \item{generic; By default libraries are installed into /usr/local/lib/snow or %LOCALAPPDATA%/lib/snow on windows}
 \item{gauche - version >= 0.9.4}
-\item{kawa - version >= 2.0; you need to add the install dir to the search path, e.g. \scheme{-Dkawa.import.path=/usr/local/share/kawa/lib}}
+\item{kawa - version >= 2.0; you need to add the install dir to the search path, e.g. \scheme{-Dkawa.import.path=/usr/local/share/kawa/lib/*.sld}}
 \item{larceny - version 0.98; you need to add "lib/Snow" to the paths in startup.sch}
 \item{sagittarius - version >= 0.9.13}
 \item{racket - version >= 8.16 with the \scheme{r7rs} pkg}

--- a/doc/chibi.scrbl
+++ b/doc/chibi.scrbl
@@ -1663,7 +1663,7 @@ installed. The following are currently supported:
 \item{foment - version >= 0.4}
 \item{generic; By default libraries are installed into /usr/local/lib/snow or %LOCALAPPDATA%/lib/snow on windows}
 \item{gauche - version >= 0.9.4}
-\item{kawa - version >= 2.0; you need to add the install dir to the search path, e.g. \scheme{-Dkawa.import.path=/usr/local/share/kawa}}
+\item{kawa - version >= 2.0; you need to add the install dir to the search path, e.g. \scheme{-Dkawa.import.path=/usr/local/share/kawa/lib}}
 \item{larceny - version 0.98; you need to add "lib/Snow" to the paths in startup.sch}
 \item{sagittarius - version >= 0.98}
 \item{stklos - version > 2.10}

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1949,45 +1949,23 @@
           impl cfg (make-path dir source-scm-file))))))))
 
 (define (kawa-installer impl cfg library dir)
-  (let* ((source-scm-file (get-library-file cfg library))
-         (source-class-file (string-append
-                          (library->path cfg library) ".class"))
-         (dest-scm-file
-          (string-append (library->path cfg library) ".scm"))
-         (dest-class-file
-          (string-append (library->path cfg library) ".class"))
-         (include-files
-          (library-include-files impl cfg (make-path dir source-scm-file)))
+  (let* ((source-class-file
+           (string-append dir
+                          "/"
+                          (path-strip-extension (get-library-file cfg library))
+                          ".class"))
          (install-dir (get-install-source-dir impl cfg))
-         (install-lib-dir (get-install-library-dir impl cfg)))
-    (let ((scm-path (make-path install-dir dest-scm-file))
-          (class-path (make-path install-lib-dir dest-class-file)))
-      (install-directory cfg (path-directory scm-path))
-      (install-directory cfg (path-directory class-path))
-      (install-file cfg (make-path dir source-scm-file) scm-path)
-      (install-file cfg (make-path dir source-class-file) class-path)
-      ;; install any includes
-      (cons
-       scm-path
-       (append
-        (map
-         (lambda (x)
-           (let ((dest-file (make-path install-dir (path-relative x dir))))
-             (install-directory cfg (path-directory dest-file))
-             (install-file cfg x dest-file)
-             dest-file))
-         include-files)
-        (map
-         (lambda (x)
-           (let* ((so-file (string-append x (cond-expand (macosx ".dylib")
-                                                         (else ".so"))))
-                  (dest-file (make-path install-lib-dir
-                                        (path-relative so-file dir))))
-             (install-directory cfg (path-directory dest-file))
-             (install-file cfg so-file dest-file)
-             dest-file))
-         (library-shared-include-files
-          impl cfg (make-path dir source-scm-file))))))))
+         (dest-class-file
+           (string-append install-dir
+                          "/"
+                          (library->path cfg library) ".class"))
+         (path (make-path install-dir dest-class-file))
+         (include-filename (string-append
+                             (path-strip-directory
+                               (path-strip-extension path))
+                             ".sld")))
+    (default-installer impl cfg library dir)
+    (install-file cfg source-class-file dest-class-file)))
 
 ;; installers should return the list of installed files
 (define (lookup-installer installer)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1954,10 +1954,12 @@
          (source-class-file (make-path dir class-file))
          (install-dir (get-install-source-dir impl cfg))
          (dest-class-file (make-path install-dir class-file))
-         (path (make-path install-dir dest-class-file)))
-    (default-installer impl cfg library dir)
-    (when (file-exists? source-class-file)
-      (install-file cfg source-class-file dest-class-file))))
+         (path (make-path install-dir dest-class-file))
+         (installed-files (default-installer impl cfg library dir)))
+    (cond ((file-exists? source-class-file)
+           (install-file cfg source-class-file dest-class-file)
+           (cons dest-class-file installed-files))
+          (else installed-files))))
 
 ;; installers should return the list of installed files
 (define (lookup-installer installer)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1949,21 +1949,12 @@
           impl cfg (make-path dir source-scm-file))))))))
 
 (define (kawa-installer impl cfg library dir)
-  (let* ((source-class-file
-           (string-append dir
-                          "/"
-                          (path-strip-extension (get-library-file cfg library))
-                          ".class"))
+  (let* ((class-file (path-replace-extension
+                       (get-library-file cfg library) "class"))
+         (source-class-file (make-path dir class-file))
          (install-dir (get-install-source-dir impl cfg))
-         (dest-class-file
-           (string-append install-dir
-                          "/"
-                          (library->path cfg library) ".class"))
-         (path (make-path install-dir dest-class-file))
-         (include-filename (string-append
-                             (path-strip-directory
-                               (path-strip-extension path))
-                             ".sld")))
+         (dest-class-file (make-path install-dir class-file))
+         (path (make-path install-dir dest-class-file)))
     (when (file-exists? source-class-file)
       (default-installer impl cfg library dir))
     (install-file cfg source-class-file dest-class-file)))

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1955,9 +1955,9 @@
          (install-dir (get-install-source-dir impl cfg))
          (dest-class-file (make-path install-dir class-file))
          (path (make-path install-dir dest-class-file)))
+    (default-installer impl cfg library dir)
     (when (file-exists? source-class-file)
-      (default-installer impl cfg library dir))
-    (install-file cfg source-class-file dest-class-file)))
+      (install-file cfg source-class-file dest-class-file))))
 
 ;; installers should return the list of installed files
 (define (lookup-installer installer)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -2157,24 +2157,15 @@
             library)))))
 
 (define (kawa-builder impl cfg library dir)
-  (let* ((library-file (get-library-file cfg library))
-         (src-library-file (make-path dir library-file))
-         (library-dir (path-directory src-library-file))
-         (dest-library-file
-          (string-append (library->path cfg library) ".class"))
-         (dest-dir
-          (path-directory (make-path dir dest-library-file))))
-    ;; ensure the build directory exists
-    (create-directory* dest-dir)
-    (with-directory
-     dir
-     (lambda ()
-       (let ((res (system 'kawa '-d dir '-C src-library-file)))
-         (and (or (and (pair? res) (zero? (cadr res)))
-                  (yes-or-no? cfg ".class file failed to build: "
-                              (library-name library)
-                              " - install anyway?"))
-              library))))))
+  (let* ((src-library-file (make-path dir (get-library-file cfg library)))
+         (res (system 'kawa
+                      '-d dir
+                      '-C src-library-file)))
+    (and (or (and (pair? res) (zero? (cadr res)))
+             (yes-or-no? cfg ".class file failed to build: "
+                         (library-name library)
+                         " - install anyway?"))
+         library)))
 
 (define (lookup-builder builder)
   (case builder

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1801,7 +1801,7 @@
 (define (get-library-extension impl cfg)
   (or (conf-get cfg 'library-extension)
       (case impl
-        ((gauche kawa) "scm")
+        ((gauche) "scm")
         (else "sld"))))
 
 (define (install-with-sudo? cfg path)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1964,7 +1964,8 @@
                              (path-strip-directory
                                (path-strip-extension path))
                              ".sld")))
-    (default-installer impl cfg library dir)
+    (when (file-exists? source-class-file)
+      (default-installer impl cfg library dir))
     (install-file cfg source-class-file dest-class-file)))
 
 ;; installers should return the list of installed files


### PR DESCRIPTION
Adds .class file compilation to snow-chibi for libraries when installing for Kawa.

Since /usr/local/share/kawa looks like this:
```
/usr/local/share/kawa/
├── bin
│   └── kawa
└── lib
    └── kawa.jar
```
I have also changed the installation path from /usr/local/share/kawa to /usr/local/share/kawa/lib. I will try to get changes merged into Kawa, so that this new path would be added by default when running Kawa with the kawa script. I do not think they would add the previous one.