### PR TITLE
Snow chibi command to install program dependencies

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -637,10 +637,10 @@
       (close-output-port out))))
 
 (define (command/install-dependencies cfg spec scm-file)
-  (let* ((dependencies
-           (map (lambda (dependency) (write-to-string dependency))
-                (cdar (extract-program-dependencies scm-file)))))
-    (apply command/install `(,cfg ,spec ,@dependencies))))
+  (apply command/install
+         `(,cfg ,spec
+                ,@(map write-to-string
+                       (cdar (extract-program-dependencies scm-file))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Index - add packages to a local repository file.

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -636,6 +636,12 @@
       (write-bytevector tarball out)
       (close-output-port out))))
 
+(define (command/install-dependencies cfg spec scm-file)
+  (let* ((dependencies
+           (map (lambda (dependency) (write-to-string dependency))
+                (cdar (extract-program-dependencies scm-file)))))
+    (apply command/install `(,cfg ,spec ,@dependencies))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Index - add packages to a local repository file.
 

--- a/lib/chibi/snow/commands.sld
+++ b/lib/chibi/snow/commands.sld
@@ -9,6 +9,7 @@
           command/implementations
           command/index
           command/install
+          command/install-dependencies
           command/remove
           command/search
           command/show

--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -111,6 +111,14 @@
      boolean ("auto-upgrade-dependencies")
      "upgrade install dependencies when newer versions are available")
     (use-sudo? symbol ("use-sudo") "always, never, or as-needed (default)")))
+(define install-dependencies-spec
+  '((skip-tests? boolean ("skip-tests") "don't run tests even if present")
+    (show-tests? boolean ("show-tests") "show test output even on success")
+    (install-tests? boolean ("install-tests") "install test-only libraries")
+    (auto-upgrade-dependencies?
+     boolean ("auto-upgrade-dependencies")
+     "upgrade install dependencies when newer versions are available")
+    (use-sudo? symbol ("use-sudo") "always, never, or as-needed (default)")))
 (define upgrade-spec
   install-spec)
 (define remove-spec '())
@@ -177,6 +185,9 @@
      (install
       "install packages"
       (@ ,install-spec) (,command/install names ...))
+     (install-dependencies
+      "install program dependencies"
+      (@ ,install-dependencies-spec) (,command/install-dependencies files ...))
      (upgrade
       "upgrade installed packages"
       (@ ,upgrade-spec) (,command/upgrade names ...))

--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -111,14 +111,7 @@
      boolean ("auto-upgrade-dependencies")
      "upgrade install dependencies when newer versions are available")
     (use-sudo? symbol ("use-sudo") "always, never, or as-needed (default)")))
-(define install-dependencies-spec
-  '((skip-tests? boolean ("skip-tests") "don't run tests even if present")
-    (show-tests? boolean ("show-tests") "show test output even on success")
-    (install-tests? boolean ("install-tests") "install test-only libraries")
-    (auto-upgrade-dependencies?
-     boolean ("auto-upgrade-dependencies")
-     "upgrade install dependencies when newer versions are available")
-    (use-sudo? symbol ("use-sudo") "always, never, or as-needed (default)")))
+(define install-dependencies-spec install-spec)
 (define upgrade-spec
   install-spec)
 (define remove-spec '())


### PR DESCRIPTION
I was thinking of something like pip freeze that would make a file with program dependencies in it. But then I realised why have another file when program has their dependencies in it. So I added a small command to install programs dependencies.

main.scm:

```
(import (scheme base)
        (scheme write)
        (retropikzel hello))

(hello)
```

Command:
```
snow-chibi install-dependencies main.scm
```

Installs (retropikzel hello).

I do think the name of the command is too long. Do you have suggestions for a better one?
