### PR TITLE
Fix Gauche library install paths in snow-chibi

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1761,6 +1761,7 @@
    ((eq? impl 'chicken) (get-install-library-dir impl cfg))
    ((eq? impl 'cyclone) (get-install-library-dir impl cfg))
    ((eq? impl 'gambit) (get-install-library-dir impl cfg))
+   ((eq? impl 'gauche) (get-install-library-dir impl cfg))
    ((eq? impl 'generic) (get-install-library-dir impl cfg))
    ((eq? impl 'guile) (get-guile-site-dir))
    ((eq? impl 'kawa) (get-install-library-dir impl cfg))
@@ -1779,6 +1780,7 @@
    ((eq? impl 'chicken) (get-install-library-dir impl cfg))
    ((eq? impl 'cyclone) (get-install-library-dir impl cfg))
    ((eq? impl 'gambit) (get-install-library-dir impl cfg))
+   ((eq? impl 'gauche) (get-install-library-dir impl cfg))
    ((eq? impl 'generic) (get-install-library-dir impl cfg))
    ((eq? impl 'kawa) (get-install-library-dir impl cfg))
    ((eq? impl 'mosh) (get-install-library-dir impl cfg))
@@ -1801,6 +1803,8 @@
                            (get-chicken-binary-version cfg))))
           (else
            (car (get-install-dirs impl cfg)))))
+   ((eq? impl 'gauche)
+    (car (get-install-dirs impl cfg)))
    ((eq? impl 'generic)
     (car (get-install-dirs impl cfg)))
    ((eq? impl 'cyclone)
@@ -1835,7 +1839,6 @@
 (define (get-library-extension impl cfg)
   (or (conf-get cfg 'library-extension)
       (case impl
-        ((gauche) "scm")
         (else "sld"))))
 
 (define (install-with-sudo? cfg path)


### PR DESCRIPTION
For some reason Gauche installs things to default path, which is not by default in Gauches loadpath. This fixes it. Also Gauche now (didnt before?) supports .sld libraries, so the ".scm" suffix is not needed.

Sorry to open two pull requests, this one is more important than https://github.com/ashinn/chibi-scheme/pull/1044 I'll update the 1044 to have these changes when/if this pull request is merged.