### PR TITLE
Improve Kawa library path finding

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1550,22 +1550,23 @@
             path
             "/usr/local/share/guile/"))))
     ((kawa)
-     (make-path
-       (if (conf-get cfg 'install-prefix) (conf-get cfg 'install-prefix) "")
-       (path-directory
-         (car
-           (string-split
-             (call-with-temp-file
-               "snow-kawa.scm"
-               (lambda (tmp-path out preserve)
-                 (with-output-to-file
-                   tmp-path
-                   (lambda ()
-                     (display "(import (scheme base) (scheme write) (scheme process-context))")
-                     (newline)
-                     (display "(display (get-environment-variable \"CLASSPATH\"))")))
-                 (process->string `(kawa ,tmp-path))))
-             #\:)))))
+     (list
+       (make-path
+         (if (conf-get cfg 'install-prefix) (conf-get cfg 'install-prefix) "")
+         (path-directory
+           (car
+             (string-split
+               (call-with-temp-file
+                 "snow-kawa.scm"
+                 (lambda (tmp-path out preserve)
+                   (with-output-to-file
+                     tmp-path
+                     (lambda ()
+                       (display "(import (scheme base) (scheme write) (scheme process-context))")
+                       (newline)
+                       (display "(display (get-environment-variable \"CLASSPATH\"))")))
+                   (process->string `(kawa ,tmp-path))))
+               #\:))))))
     ((loko)
      (list "/usr/local/share/r6rs"))
     ((mit-scheme)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1553,20 +1553,17 @@
      (list
        (make-path
          (if (conf-get cfg 'install-prefix) (conf-get cfg 'install-prefix) "")
-         (path-directory
-           (car
-             (string-split
-               (call-with-temp-file
-                 "snow-kawa.scm"
-                 (lambda (tmp-path out preserve)
-                   (with-output-to-file
-                     tmp-path
-                     (lambda ()
-                       (display "(import (scheme base) (scheme write) (scheme process-context))")
-                       (newline)
-                       (display "(display (get-environment-variable \"CLASSPATH\"))")))
-                   (process->string `(kawa ,tmp-path))))
-               #\:))))))
+         (let ((kawa-classpath
+                 (string-split
+                   (process->string
+                     `(kawa -e "(display (get-environment-variable \"CLASSPATH\"))"))
+                   #\.)))
+           (if (or (null? kawa-classpath)
+                   (not (string-suffix? "kawa" (car kawa-classpath))))
+             "/usr/local/share/kawa/lib"
+             (string-copy (car kawa-classpath)
+                          0
+                          (- (string-length (car kawa-classpath)) 4)))))))
     ((loko)
      (list "/usr/local/share/r6rs"))
     ((mit-scheme)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1557,13 +1557,13 @@
                  (string-split
                    (process->string
                      `(kawa -e "(display (get-environment-variable \"CLASSPATH\"))"))
-                   #\.)))
+                   #\:)))
            (if (or (null? kawa-classpath)
-                   (not (string-suffix? "kawa" (car kawa-classpath))))
+                   (not (string-suffix? "kawa.jar" (car kawa-classpath))))
              "/usr/local/share/kawa/lib"
              (string-copy (car kawa-classpath)
                           0
-                          (- (string-length (car kawa-classpath)) 4)))))))
+                          (- (string-length (car kawa-classpath)) 8)))))))
     ((loko)
      (list "/usr/local/share/r6rs"))
     ((mit-scheme)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1550,7 +1550,22 @@
             path
             "/usr/local/share/guile/"))))
     ((kawa)
-     (list "/usr/local/share/kawa/lib"))
+     (make-path
+       (if (conf-get cfg 'install-prefix) (conf-get cfg 'install-prefix) "")
+       (path-directory
+         (car
+           (string-split
+             (call-with-temp-file
+               "snow-kawa.scm"
+               (lambda (tmp-path out preserve)
+                 (with-output-to-file
+                   tmp-path
+                   (lambda ()
+                     (display "(import (scheme base) (scheme write) (scheme process-context))")
+                     (newline)
+                     (display "(display (get-environment-variable \"CLASSPATH\"))")))
+                 (process->string `(kawa ,tmp-path))))
+             #\:)))))
     ((loko)
      (list "/usr/local/share/r6rs"))
     ((mit-scheme)


### PR DESCRIPTION
Kawa binary sets first item of CLASSPATH to be, on default install, /usr/local/share/lib/kawa/kawa.jar. So the library install path can be taken from there. It now works even when Kawa is not installed with default configuration.

Additionally --install-prefix option is also added before the install path.