### PR TITLE
Do not install natively supported libraries

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -3014,10 +3014,11 @@
             (if (member (car ls) lib-names)
                 (warn "skipping already installed library: " (car ls)))
             (lp (cdr ls) res (cons (car ls) ignored)))
-           ((and (null? candidates)
-                 (not (assoc (car ls) current))
+           ((and (not (assoc (car ls) current))
                  (pair? (car ls))
                  (implementation-supports-natively? impl cfg (car ls)))
+            (when (and (car ls) (equal? (car (car ls)) 'srfi))
+              (warn "skipping natively supported SRFI" (car ls)))
             ;; assume certain core libraries already installed
             ;; (info "assuming core library installed: " (car ls))
             (lp (cdr ls) res (cons (car ls) ignored)))


### PR DESCRIPTION
Related to #1078 

- Ignore native libraries even when snow-fort package exists
- Add warning when not installing SRFI that is natively supported

Correct me if I am wrong but now that the SRFI support check bug is fixed I think the `(null? candidates)` is a bug. Because the behaviour before these changes was:
`snow-chibi install --impls=kawa srfi.1` is not installed because there is no package in snow-fort.
`snow-chibi install --impls=kawa srfi.39` is  installed because there is package in snow-fort.

And after these changes neither is installed, and warning is issued on both occasions that they are skipped.