### PR TITLE
Fix string-append problem with tr7 when file is #f

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1766,7 +1766,7 @@
              `(stklos -A ,install-dir ,file)))
         ((tr7)
          (if lib-path
-             `(sh -c ,(string-append "TR7_LIB_PATH=" lib-path " tr7i " file))
+             `(sh -c ,(string-append "TR7_LIB_PATH=" lib-path " tr7i " (if file file "")))
              `(tr7i ,file)))
         ((ypsilon)
          (if lib-path


### PR DESCRIPTION
Since tr7 has string-append in scheme-program-command, when file is #f there is an error. This fixes that.