### PR TITLE
Kawa fixes

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -2642,12 +2642,13 @@
 
 (define (kawa-builder impl cfg library dir)
   (let* ((src-library-file (make-path dir (get-library-file cfg library)))
-         (res (system 'kawa
-                      (string-append "-Dkawa.import.path="
-                                     (car (get-install-dirs impl cfg)))
-                      '-d dir
-                      '-C src-library-file)))
-    (and (or (and (pair? res) (zero? (cadr res)))
+         (res (process->output+error+status
+                (string-append "kawa -Dkawa.import.path="
+                               (car (get-install-dirs impl cfg))
+                               " -d " dir
+                               " -C " src-library-file))))
+    (and (or (and (list? res)
+                  (zero? (car (reverse res))))
              (yes-or-no? cfg ".class file failed to build: "
                          (library-name library)
                          " - install anyway?"))

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -2642,13 +2642,14 @@
 
 (define (kawa-builder impl cfg library dir)
   (let* ((src-library-file (make-path dir (get-library-file cfg library)))
-         (res (process->output+error+status
-                (string-append "kawa -Dkawa.import.path="
-                               (car (get-install-dirs impl cfg))
-                               " -d " dir
-                               " -C " src-library-file))))
-    (and (or (and (list? res)
-                  (zero? (car (reverse res))))
+         (res (system 'kawa
+                      (string-append "-Dkawa.import.path="
+                                     (car (get-install-dirs impl cfg)))
+                      '-d dir
+                      '-C src-library-file)))
+    ;; Installing for Kawa fails if there is stdin, this fixes it for some reason
+    (write res (open-output-string))
+    (and (or (and (pair? res) (zero? (cadr res)))
              (yes-or-no? cfg ".class file failed to build: "
                          (library-name library)
                          " - install anyway?"))

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -2647,7 +2647,8 @@
                                      (car (get-install-dirs impl cfg)))
                       '-d dir
                       '-C src-library-file)))
-    ;; Installing for Kawa fails if there is stdin, this fixes it for some reason
+    ;; Installing for Kawa fails if there is no terminal and/or stdin, this
+    ;; fixes it for some reason
     (write res (open-output-string))
     (and (or (and (pair? res) (zero? (cadr res)))
              (yes-or-no? cfg ".class file failed to build: "


### PR DESCRIPTION
When running Kawa inside Docker without -it flags which do this
```
  -i, --interactive                      Keep STDIN open even if not attached
  -t, --tty                              Allocate a pseudo-TTY
```

Installing for example SRFI-180 from here https://github.com/srfi-explorations/r7rs-srfi for running tests does not work. srfi/180.sld does not exists in the tmp directory. I'm not sure why it happens and what is causing it. Sometimes with Kawa I noticed I needed to use (newline) to get output to appear. So maybe it is something related to that.

Anyway, this fixes it for some reason. Not a perfect fix but I dont have time to do a thorough investigation now.