### PR TITLE
Install the helper scripts with correct permissions when using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,7 +678,7 @@ install(TARGETS libchibi-scheme libchibi-common chibi-scheme
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-install(FILES
+install(PROGRAMS
     tools/chibi-ffi
     tools/chibi-doc
     tools/snow-chibi


### PR DESCRIPTION
If I install chibi-scheme using CMake, all the helper scripts end up without execute permissions.

From [CMake v3.16 documentation](https://cmake.org/cmake/help/v3.16/command/install.html#programs) (it's the same in [latest](https://cmake.org/cmake/help/latest/command/install.html#programs)):
> The `PROGRAMS` form is identical to the `FILES` form except that the default permissions for the installed file also include `OWNER_EXECUTE`, `GROUP_EXECUTE`, and `WORLD_EXECUTE`. This form is intended to install programs that are not targets, such as shell scripts. Use the `TARGETS` form to install targets built within the project.

The reproduction scenario:
```
% cmake --version
cmake version 4.2.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).

% git clone https://github.com/ashinn/chibi-scheme; cd chibi-scheme
[skipped]

% git rev-parse HEAD
ca9e24ad200a9f69633fd98391d8179216af297a

% cmake -G Ninja -S . -B Build  
[skipped]

% cmake --build Build
[skipped]

% cmake --install Build --prefix destdir
[skipped]

% ls -l destdir/bin
total 288
-rw-r--r-- 1 nope nope  2295 Apr 12 13:38 chibi-doc
-rw-r--r-- 1 nope nope 92592 Apr 12 13:38 chibi-ffi
-rwxr-xr-x 1 nope nope 88016 Apr 12 13:44 chibi-scheme
-rw-r--r-- 1 nope nope   570 Apr 12 13:38 snow-chibi
-rw-r--r-- 1 nope nope  8675 Apr 12 13:38 snow-chibi.scm
```