### PR TITLE
Do not show full error message when config file does not exist

### DIFF
--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -5,6 +5,7 @@
 
 (import (scheme base)
         (scheme process-context)
+        (scheme file)
         (chibi snow commands)
         (chibi snow interface)
         (chibi app)
@@ -231,6 +232,13 @@
       (,app-help-command args ...))
      )))
 
-(run-application app-spec
-                 (command-line)
-                 (conf-load (conf-default-path "snow")))
+(run-application
+  app-spec
+  (command-line)
+  (let ((conf-file (conf-default-path "snow")))
+    (cond ((file-exists? conf-file)
+           (conf-load conf-file))
+          (else
+            (warn "couldn't load config (file does not exist)" conf-file)
+            (parameterize ((current-error-port (open-output-string)))
+              (conf-load conf-file))))))

--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -6,6 +6,7 @@
 (import (scheme base)
         (scheme process-context)
         (scheme file)
+        (scheme time)
         (chibi snow commands)
         (chibi snow interface)
         (chibi app)
@@ -238,7 +239,5 @@
   (let ((conf-file (conf-default-path "snow")))
     (cond ((file-exists? conf-file)
            (conf-load conf-file))
-          (else
-            (warn "snow config file not found: " conf-file)
-            (parameterize ((current-error-port (open-output-string)))
-              (conf-load conf-file))))))
+          (else (warn "snow config file not found: " conf-file)
+                (make-conf '() #f #f (current-second))))))

--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -239,6 +239,6 @@
     (cond ((file-exists? conf-file)
            (conf-load conf-file))
           (else
-            (warn "couldn't load config (file does not exist)" conf-file)
+            (warn "snow config file not found: " conf-file)
             (parameterize ((current-error-port (open-output-string)))
               (conf-load conf-file))))))


### PR DESCRIPTION
Continuation of https://github.com/ashinn/chibi-scheme/issues/1111

What do you think about this? I added `(file does not exist)` so that the message is still there. But now it is a warning instead of error and only one line. It might be a bit weird way to do it but I did not want to change the (chibi config) library.