### PR TITLE
Prettier (less redundant and noisy) assert in SRFI 253

### DIFF
--- a/lib/srfi/253/impl.scm
+++ b/lib/srfi/253/impl.scm
@@ -25,7 +25,7 @@
 (define-syntax check-arg
   (syntax-rules ()
     ((_ pred val caller)
-     (assert (pred val) "argument should match the specification" '(pred val) val caller))
+     (assert (pred val) val caller))
     ((_ pred val)
      (check-arg pred val 'check-arg))))
 


### PR DESCRIPTION
I haven’t changed the sample implementation `assert` when contributing SRFI 253. But now that I used it somewhat, I see that some of that data was extraneous, as Chibi `assert` already provides some info. Thus the shortened version here.