### PR TITLE
Show error when packaging and file doesnt exist

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -604,6 +604,18 @@
                                      (string-prefix? "https://" x))))
                           docs)
                   tar-data-files files))))
+          ;; Check that all files exist
+          (for-each
+            (lambda (file)
+              (cond
+                ((string? file)
+                 (when (not (file-exists? file))
+                   (die 2 "No packages generated, file not found: " file)))
+                ((and (list? file)
+                      (equal? (car file) 'rename))
+                 (when (not (file-exists? (cadr file)))
+                   (die 2 "No packages generated, file not found: " (cadr file))))))
+            tar-files)
           (cons `(package
                   ,@(reverse res)
                   ,@(if (pair? data-files) `((data-files ,@pkg-data-files)) '())


### PR DESCRIPTION
foo/bar.sld:
```
(define-library
  (foo bar)
  (import (scheme base))
  (export baz)
  (include "bar.scm"))
```
foo/bar.scm does not exist.

Previously:
```
snow-chibi package foo/bar.sld
ERROR in "file-link-status": invalid type, expected String: #f
  called from <anonymous> on line 279 of file /usr/local/share/chibi/init-7.scm
  called from <anonymous> on line 247 of file /usr/local/share/chibi/chibi/tar.scm
  called from lp on line 8 of file /usr/local/share/chibi/srfi/1/fold.scm
  called from <anonymous> on line 237 of file /usr/local/share/chibi/chibi/tar.scm
  called from create-package on line 643 of file /usr/local/share/chibi/chibi/snow/commands.scm
  called from <anonymous> on line 650 of file /usr/local/share/chibi/chibi/snow/commands.scm
  called from <anonymous> on line 179 of file /usr/local/share/chibi/chibi/app.scm
  called from <anonymous> on line 1268 of file /usr/local/share/chibi/init-7.scm
  called from <anonymous> on line 800 of file /usr/local/share/chibi/init-7.scm
```

Now:
```
snow-chibi package foo/bar.sld 
No packages generated, file not found: ./foo/bar.scm
```

Same should happen with --programs, --data-files and so on.