### PR TITLE
Support for net on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ build-lib/chibi/char-set/width.scm
 
 # vim swapfiles
 *.swp
+
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,12 @@ SNOW_CHIBI ?= tools/snow-chibi
 ########################################################################
 
 CHIBI_COMPILED_LIBS = lib/chibi/filesystem$(SO) lib/chibi/weak$(SO) \
+        lib/chibi/net$(SO) \
 	lib/chibi/heap-stats$(SO) lib/chibi/disasm$(SO) lib/chibi/ast$(SO) \
 	lib/chibi/json$(SO) lib/chibi/emscripten$(SO)
 CHIBI_POSIX_COMPILED_LIBS = lib/chibi/process$(SO) lib/chibi/time$(SO) \
 	lib/chibi/system$(SO) lib/chibi/stty$(SO) lib/chibi/pty$(SO) \
-	lib/chibi/net$(SO) lib/srfi/18/threads$(SO)
+	lib/srfi/18/threads$(SO)
 CHIBI_WIN32_COMPILED_LIBS = lib/chibi/win32/process-win32$(SO)
 CHIBI_CRYPTO_COMPILED_LIBS = lib/chibi/crypto/crypto$(SO)
 CHIBI_IO_COMPILED_LIBS = lib/chibi/io/io$(SO)

--- a/Makefile.detect
+++ b/Makefile.detect
@@ -173,6 +173,10 @@ XLDFLAGS += -lsocket
 XCPPFLAGS += -D_POSIX_PTHREAD_SEMANTICS
 endif
 
+ifeq ($(PLATFORM),windows)
+XLIBS += -lws2_32
+endif
+
 # Choose compiled library on MSYS
 ifeq ($(OS), Windows_NT)
 ifeq ($(PLATFORM),msys)

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -512,7 +512,9 @@ struct sexp_struct {
     struct {
       char openp, no_closep;
       sexp_sint_t fd, count;
+#ifdef _WIN32      
       SOCKET_TYPE sock;
+#endif      
     } fileno;
     struct {
       sexp kind, message, irritants, procedure, source, stack_trace;
@@ -1272,7 +1274,11 @@ enum sexp_uniform_vector_type {
 #define sexp_fileno_fd(f)        (sexp_pred_field(f, fileno, sexp_filenop, fd))
 #define sexp_fileno_count(f)     (sexp_pred_field(f, fileno, sexp_filenop, count))
 #define sexp_fileno_openp(f)     (sexp_pred_field(f, fileno, sexp_filenop, openp))
+#ifdef _WIN32
 #define sexp_fileno_sock(f)      (sexp_pred_field(f, fileno, sexp_filenop, sock))
+#else
+#define sexp_fileno_sock(f)      (sexp_port_fd(f))
+#endif
 #define sexp_fileno_no_closep(f) (sexp_pred_field(f, fileno, sexp_filenop, no_closep))
 
 #define sexp_ratio_numerator(q)   (sexp_pred_field(q, ratio, sexp_ratiop, numerator))
@@ -1780,7 +1786,6 @@ SEXP_API sexp sexp_write_to_string (sexp ctx, sexp obj);
 SEXP_API sexp sexp_write_simple_object (sexp ctx, sexp self, sexp_sint_t n, sexp obj, sexp writer, sexp out);
 SEXP_API sexp sexp_finalize_port (sexp ctx, sexp self, sexp_sint_t n, sexp port);
 SEXP_API sexp sexp_make_fileno_op (sexp ctx, sexp self, sexp_sint_t n, sexp fd, sexp no_closep);
-SEXP_API sexp sexp_make_fileno_sock (sexp ctx, sexp self, sexp_sint_t fd, SOCKET_TYPE sock);
 SEXP_API sexp sexp_make_input_port (sexp ctx, FILE* in, sexp name);
 SEXP_API sexp sexp_make_output_port (sexp ctx, FILE* out, sexp name);
 SEXP_API sexp sexp_open_input_file_descriptor (sexp ctx, sexp self, sexp_sint_t n, sexp fileno, sexp socketp);

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -18,6 +18,14 @@ extern "C" {
 #include "chibi/features.h"
 #include "chibi/install.h"
 
+#if !(defined _WIN32) || defined(__CYGWIN__)
+#include <sys/socket.h>
+#define SOCKET_TYPE sexp_sint_t
+#else
+#include <winsock2.h>
+#define SOCKET_TYPE SOCKET
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #include <errno.h>
@@ -96,9 +104,6 @@ typedef s64int int64_t;
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
-#if !(defined _WIN32) || defined(__CYGWIN__)
-#include <sys/socket.h>
-#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #define _REENTRANT 1
@@ -507,6 +512,7 @@ struct sexp_struct {
     struct {
       char openp, no_closep;
       sexp_sint_t fd, count;
+      SOCKET_TYPE sock;
     } fileno;
     struct {
       sexp kind, message, irritants, procedure, source, stack_trace;
@@ -1266,7 +1272,7 @@ enum sexp_uniform_vector_type {
 #define sexp_fileno_fd(f)        (sexp_pred_field(f, fileno, sexp_filenop, fd))
 #define sexp_fileno_count(f)     (sexp_pred_field(f, fileno, sexp_filenop, count))
 #define sexp_fileno_openp(f)     (sexp_pred_field(f, fileno, sexp_filenop, openp))
-#define sexp_fileno_socketp(f)   (sexp_pred_field(f, fileno, sexp_filenop, socketp))
+#define sexp_fileno_sock(f)      (sexp_pred_field(f, fileno, sexp_filenop, sock))
 #define sexp_fileno_no_closep(f) (sexp_pred_field(f, fileno, sexp_filenop, no_closep))
 
 #define sexp_ratio_numerator(q)   (sexp_pred_field(q, ratio, sexp_ratiop, numerator))
@@ -1679,6 +1685,7 @@ SEXP_API int sexp_buffered_flush (sexp ctx, sexp p, int forcep);
 #define sexp_newline(ctx, p) sexp_write_char((ctx), '\n', (p))
 #define sexp_at_eofp(p)      (feof(sexp_port_stream(p)))
 #define sexp_port_fileno(p)  (sexp_port_stream(p) ? fileno(sexp_port_stream(p)) : sexp_filenop(sexp_port_fd(p)) ? sexp_fileno_fd(sexp_port_fd(p)) : -1)
+#define sexp_port_sock(p)  (sexp_port_stream(p) ? -1 : sexp_filenop(sexp_port_fd(p)) ? sexp_fileno_sock(sexp_port_fd(p)) : -1)
 
 #if SEXP_USE_AUTOCLOSE_PORTS
 #define SEXP_FINALIZE_PORT sexp_finalize_port
@@ -1773,6 +1780,7 @@ SEXP_API sexp sexp_write_to_string (sexp ctx, sexp obj);
 SEXP_API sexp sexp_write_simple_object (sexp ctx, sexp self, sexp_sint_t n, sexp obj, sexp writer, sexp out);
 SEXP_API sexp sexp_finalize_port (sexp ctx, sexp self, sexp_sint_t n, sexp port);
 SEXP_API sexp sexp_make_fileno_op (sexp ctx, sexp self, sexp_sint_t n, sexp fd, sexp no_closep);
+SEXP_API sexp sexp_make_fileno_sock (sexp ctx, sexp self, sexp_sint_t fd, SOCKET_TYPE sock);
 SEXP_API sexp sexp_make_input_port (sexp ctx, FILE* in, sexp name);
 SEXP_API sexp sexp_make_output_port (sexp ctx, FILE* out, sexp name);
 SEXP_API sexp sexp_open_input_file_descriptor (sexp ctx, sexp self, sexp_sint_t n, sexp fileno, sexp socketp);

--- a/lib/chibi/accept.c
+++ b/lib/chibi/accept.c
@@ -4,6 +4,12 @@
 /* EWOULDBLOCK and block on the socket, and listen should automatically make */
 /* sockets non-blocking. */
 
+sexp sexp_make_fileno_sock(sexp ctx, sexp self, sexp_sint_t fd, SOCKET_TYPE sock) {
+  sexp res = sexp_make_fileno(ctx, sexp_make_fixnum(fd), SEXP_FALSE);
+  sexp_fileno_sock(res) = sock;
+  return res;
+}
+
 sexp sexp_socket(sexp ctx, sexp self, int af, int type, int protocol) {
 #ifdef _WIN32
   SOCKET_TYPE sock = WSASocket(af, type, protocol, NULL, 0, 0);

--- a/lib/chibi/accept.c
+++ b/lib/chibi/accept.c
@@ -4,12 +4,22 @@
 /* EWOULDBLOCK and block on the socket, and listen should automatically make */
 /* sockets non-blocking. */
 
-sexp sexp_accept (sexp ctx, sexp self, int sock, struct sockaddr* addr, socklen_t len) {
+sexp sexp_socket(sexp ctx, sexp self, int af, int type, int protocol) {
+#ifdef _WIN32
+  SOCKET_TYPE sock = WSASocket(af, type, protocol, NULL, 0, 0);
+  int fd = _open_osfhandle(sock, _O_RDWR | _O_BINARY);
+#else
+  SOCKET_TYPE sock = socket(af, type, protocol);
+  int fd = sock;
+#endif  
+  return sexp_make_fileno_sock(ctx, self, fd, sock);
+}
+
+sexp sexp_accept(sexp ctx, sexp self, SOCKET_TYPE sock, struct sockaddr* addr, socklen_t len) {
 #if SEXP_USE_GREEN_THREADS
   sexp f;
 #endif
-  int res;
-  res = accept(sock, addr, &len);
+  SOCKET_TYPE res = accept(sock, addr, &len);
 #if SEXP_USE_GREEN_THREADS
   if (res < 0 && errno == EWOULDBLOCK) {
     f = sexp_global(ctx, SEXP_G_THREADS_BLOCKER);
@@ -18,17 +28,28 @@ sexp sexp_accept (sexp ctx, sexp self, int sock, struct sockaddr* addr, socklen_
       return sexp_global(ctx, SEXP_G_IO_BLOCK_ERROR);
     }
   }
+#ifdef _WIN32
+  if (res >= 0)
+    ioctlsocket(res, FIONBIO, &mode);
+#else
   if (res >= 0)
     fcntl(res, F_SETFL, fcntl(res, F_GETFL) | O_NONBLOCK);
 #endif
-  return sexp_make_fileno(ctx, sexp_make_fixnum(res), SEXP_FALSE);
+#endif
+#ifdef _WIN32
+  int fd = _open_osfhandle(res, _O_RDWR | _O_BINARY);
+#else
+  int fd = res;
+  int i = errno;
+#endif 
+  return sexp_make_fileno_sock(ctx, self, fd, res);
 }
 
 /* likewise sendto and recvfrom should suspend the thread gracefully */
 
 #define sexp_zerop(x) ((x) == SEXP_ZERO || (sexp_flonump(x) && sexp_flonum_value(x) == 0.0))
 
-sexp sexp_sendto (sexp ctx, sexp self, int sock, const void* buffer, size_t len, int flags, struct sockaddr* addr, socklen_t addr_len, sexp timeout) {
+sexp sexp_sendto (sexp ctx, sexp self, SOCKET_TYPE sock, const void* buffer, size_t len, int flags, struct sockaddr* addr, socklen_t addr_len, sexp timeout) {
 #if SEXP_USE_GREEN_THREADS
   sexp f;
 #endif
@@ -46,7 +67,7 @@ sexp sexp_sendto (sexp ctx, sexp self, int sock, const void* buffer, size_t len,
   return sexp_make_fixnum(res);
 }
 
-sexp sexp_recvfrom (sexp ctx, sexp self, int sock, void* buffer, size_t len, int flags, struct sockaddr* addr, socklen_t addr_len, sexp timeout) {
+sexp sexp_recvfrom (sexp ctx, sexp self, SOCKET_TYPE sock, void* buffer, size_t len, int flags, struct sockaddr* addr, socklen_t addr_len, sexp timeout) {
 #if SEXP_USE_GREEN_THREADS
   sexp f;
 #endif
@@ -67,24 +88,32 @@ sexp sexp_recvfrom (sexp ctx, sexp self, int sock, void* buffer, size_t len, int
 /* If we're binding or listening on a socket from Scheme, we most */
 /* likely want it to be non-blocking. */
 
-sexp sexp_bind (sexp ctx, sexp self, int fd, struct sockaddr* addr, socklen_t addr_len) {
+sexp sexp_bind (sexp ctx, sexp self, SOCKET_TYPE fd, struct sockaddr* addr, socklen_t addr_len) {
   int res = bind(fd, addr, addr_len);
 #if SEXP_USE_GREEN_THREADS
+#ifdef _WIN32
+  if (res >= 0)
+    ioctlsocket(fd, FIONBIO, &mode);
+#else
   if (res >= 0)
     fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+#endif
 #endif
   return (res == 0) ? SEXP_TRUE : SEXP_FALSE;
 }
 
-sexp sexp_listen (sexp ctx, sexp self, sexp fileno, sexp backlog) {
-  int fd, res;
-  sexp_assert_type(ctx, sexp_filenop, SEXP_FILENO, fileno);
-  sexp_assert_type(ctx, sexp_fixnump, SEXP_FIXNUM, backlog);
-  fd = sexp_fileno_fd(fileno);
-  res = listen(fd, sexp_unbox_fixnum(backlog));
+sexp sexp_listen (sexp ctx, sexp self, SOCKET_TYPE fd, int backlog) {
+  int res;
+  unsigned long mode = 1; 
+  res = listen(fd, backlog);
 #if SEXP_USE_GREEN_THREADS
+#ifdef _WIN32
+  if (res >= 0)
+    ioctlsocket(fd, FIONBIO, &mode);
+#else
   if (res >= 0)
     fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+#endif
 #endif
   return (res == 0) ? SEXP_TRUE : SEXP_FALSE;
 }
@@ -108,3 +137,20 @@ int sexp_sockaddr_port (sexp ctx, sexp self, struct sockaddr* addr) {
   struct sockaddr_in *sa = (struct sockaddr_in *)addr;
   return ntohs(sa->sin_port);
 }
+
+int sexp_setsockopt(SOCKET_TYPE socket, int level, int option_name, int *option_value, socklen_t option_len) {
+#ifdef _WIN32
+  return setsockopt(socket, level, option_name, (const char*)option_value, option_len);
+#else
+  return setsockopt(socket, level, option_name, (const void*)option_value, option_len);
+#endif
+}
+
+int sexp_getsockopt(SOCKET_TYPE socket, int level, int option_name, int *option_value, socklen_t *option_len) {
+#ifdef _WIN32
+  return getsockopt(socket, level, option_name, (char*)option_value, option_len);
+#else
+  return getsockopt(socket, level, option_name, (void*)option_value, option_len);
+#endif
+}
+

--- a/lib/chibi/net.stub
+++ b/lib/chibi/net.stub
@@ -1,9 +1,15 @@
-
-(c-system-include "arpa/inet.h")
-(c-system-include "sys/types.h")
-(c-system-include "sys/socket.h")
-(c-system-include "netinet/in.h")
-(c-system-include "netdb.h")
+(cond-expand
+  (windows
+   (c-system-include "winsock2.h")
+   (c-system-include "ws2tcpip.h")
+   (c-system-include "fcntl.h"))
+  (else
+    (c-system-include "arpa/inet.h")
+    (c-system-include "sys/types.h")
+    (c-system-include "sys/socket.h")
+    (c-system-include "netinet/in.h")
+    (c-system-include "netdb.h"))
+)
 
 (define-c-int-type socklen_t)
 
@@ -34,41 +40,44 @@
 ;;> Bind a name to a socket.
 
 (define-c sexp (bind "sexp_bind")
-  ((value ctx sexp) (value self sexp) fileno sockaddr int))
+  ((value ctx sexp) (value self sexp) fileno-socket sockaddr int))
 
 ;;> Listen on a socket.
 
 (define-c sexp (listen "sexp_listen")
-  ((value ctx sexp) (value self sexp) sexp sexp))
+  ((value ctx sexp) (value self sexp) fileno-socket int))
 
 ;;> Accept a connection on a socket.
 
 (define-c sexp (accept "sexp_accept")
-  ((value ctx sexp) (value self sexp) fileno sockaddr int))
+  ((value ctx sexp) (value self sexp) fileno-socket sockaddr int))
 
 ;;> Create an endpoint for communication.
 
-(define-c fileno socket (int int int))
+(define-c sexp (socket "sexp_socket") 
+  ((value ctx sexp) (value self sexp) int int int))
 
 ;;> Initiate a connection on a socket.
 
-(define-c int connect (fileno sockaddr int))
+(define-c int connect (fileno-socket sockaddr int))
 
 (define-c sexp (%send "sexp_sendto")
   ((value ctx sexp) (value self sexp)
-   fileno bytevector (value (bytevector-length arg3) size_t) int
+   fileno-socket bytevector (value (bytevector-length arg3) size_t) int
    (maybe-null sockaddr) socklen_t sexp))
 
 (define-c sexp (%receive! "sexp_recvfrom")
   ((value ctx sexp) (value self sexp)
-   fileno bytevector (value (bytevector-length arg3) size_t) int
+   fileno-socket bytevector (value (bytevector-length arg3) size_t) int
    (maybe-null sockaddr) socklen_t sexp))
 
 ;;> Returns a list of 2 new sockets, the input and output end of a new
 ;;> pipe, respectively.
-
-(define-c errno (open-socket-pair "socketpair")
-  (int int int (result (array fileno 2))))
+(cond-expand
+  (windows)
+  (else 
+    (define-c errno (open-socket-pair "socketpair")
+      (int int int (result (array fileno 2))))))
 
 ;;> Return the IP address of a sockaddr as an "N.N.N.N" string.
 
@@ -101,17 +110,17 @@
 (c-include-verbatim "accept.c")
 
 (define-c errno (get-peer-name getpeername)
-  (fileno sockaddr (result (value (sizeof sockaddr) socklen_t))))
+  (fileno-socket sockaddr (result (value (sizeof sockaddr) socklen_t))))
 
-(define-c errno getsockopt
-  (fileno int int (result int) (result (value (sizeof int) socklen_t))))
+(define-c errno (getsockopt "sexp_getsockopt")
+  (fileno-socket int int (result int) (result (value (sizeof int) socklen_t))))
 
 ;;> Set an option for the given socket.  For example, to make the
 ;;> address reusable:
 ;;> \scheme{(set-socket-option! sock level/socket socket-opt/reuseaddr 1)}
 
-(define-c errno (set-socket-option! "setsockopt")
-  (fileno int int (pointer int) (value (sizeof int) socklen_t)))
+(define-c errno (set-socket-option! "sexp_setsockopt")
+  (fileno-socket int int (pointer int) (value (sizeof int) socklen_t)))
 
 (define-c-const int (level/socket "SOL_SOCKET"))
 
@@ -125,6 +134,10 @@
 (define-c-const int (socket-opt/dontroute "SO_DONTROUTE"))
 (define-c-const int (socket-opt/rcvlowat "SO_RCVLOWAT"))
 (define-c-const int (socket-opt/sndlowat "SO_SNDLOWAT"))
+
+(cond-expand
+  (windows
+    (c-init "  WSADATA wsaData = {0}; int wsastartupr = WSAStartup(MAKEWORD(2, 2), &wsaData); ")))
 
 ;;> The constants for the \scheme{get-socket-option} and
 ;;> \scheme{set-socket-option!}.

--- a/sexp.c
+++ b/sexp.c
@@ -206,31 +206,15 @@ sexp sexp_finalize_port (sexp ctx, sexp self, sexp_sint_t n, sexp port) {
   if (sexp_port_openp(port)) {
     sexp_port_openp(port) = 0;
     if (sexp_oportp(port)) sexp_flush_forced(ctx, port);
-#ifdef _WIN32
-    if (sexp_filenop(sexp_port_fd(port))
-        && sexp_fileno_openp(sexp_port_fd(port))) {
-      if (sexp_port_shutdownp(port)) {
-      /* shutdown the socket if requested */
-      if (sexp_iportp(port))
-        shutdown(sexp_port_sock(port), sexp_oportp(port) ? SD_BOTH : SD_RECEIVE);
-      if (sexp_oportp(port))
-        shutdown(sexp_port_sock(port), SD_SEND);
-    }
-    if (!sexp_port_no_closep(port)) {
-      if (--sexp_fileno_count(sexp_port_fd(port)) == 0)
-        sexp_finalize_fileno(ctx, self, n, sexp_port_fd(port));
-    }
-}
-#elif defined(PLAN9)
-#else
+#ifndef PLAN9
     if (sexp_filenop(sexp_port_fd(port))
         && sexp_fileno_openp(sexp_port_fd(port))) {
       if (sexp_port_shutdownp(port)) {
         /* shutdown the socket if requested */
         if (sexp_iportp(port))
-          shutdown(sexp_port_fileno(port), sexp_oportp(port) ? SHUT_RDWR : SHUT_RD);
+          shutdown(sexp_port_sock(port), sexp_oportp(port) ? SHUT_RDWR : SHUT_RD);
         if (sexp_oportp(port))
-          shutdown(sexp_port_fileno(port), SHUT_WR);
+          shutdown(sexp_port_sock(port), SHUT_WR);
       }
       if (!sexp_port_no_closep(port)) {
         if (--sexp_fileno_count(sexp_port_fd(port)) == 0)
@@ -1982,31 +1966,6 @@ sexp sexp_make_fileno_op (sexp ctx, sexp self, sexp_sint_t n, sexp fd, sexp no_c
     sexp_fileno_fd(res) = sexp_unbox_fixnum(fd);
     sexp_fileno_openp(res) = 1;
     sexp_fileno_no_closep(res) = sexp_truep(no_closep);
-#if SEXP_USE_UNIFY_FILENOS_BY_NUMBER
-    sexp_insert_fileno(ctx, res);
-#endif
-  }
-  sexp_gc_release1(ctx);
-  return res;
-}
-
-sexp sexp_make_fileno_sock (sexp ctx, sexp self, sexp_sint_t fd, SOCKET_TYPE sock) {
-  sexp_gc_var1(res);
-#if SEXP_USE_UNIFY_FILENOS_BY_NUMBER
-  res = sexp_lookup_fileno(ctx, fd);
-  if (sexp_filenop(res)) {
-    sexp_fileno_no_closep(res) = sexp_truep(no_closep);
-    sexp_fileno_openp(res) = 1;  /* not necessarily */
-    return res;
-  }
-#endif
-  sexp_gc_preserve1(ctx, res);
-  res = sexp_alloc_type(ctx, fileno, SEXP_FILENO);
-  if (!sexp_exceptionp(res)) {
-    sexp_fileno_fd(res) = fd;
-    sexp_fileno_openp(res) = 1;
-    sexp_fileno_no_closep(res) = 0;
-    sexp_fileno_sock(res) = sock;
 #if SEXP_USE_UNIFY_FILENOS_BY_NUMBER
     sexp_insert_fileno(ctx, res);
 #endif

--- a/sexp.c
+++ b/sexp.c
@@ -206,7 +206,23 @@ sexp sexp_finalize_port (sexp ctx, sexp self, sexp_sint_t n, sexp port) {
   if (sexp_port_openp(port)) {
     sexp_port_openp(port) = 0;
     if (sexp_oportp(port)) sexp_flush_forced(ctx, port);
-#ifndef PLAN9
+#ifdef _WIN32
+    if (sexp_filenop(sexp_port_fd(port))
+        && sexp_fileno_openp(sexp_port_fd(port))) {
+      if (sexp_port_shutdownp(port)) {
+      /* shutdown the socket if requested */
+      if (sexp_iportp(port))
+        shutdown(sexp_port_sock(port), sexp_oportp(port) ? SD_BOTH : SD_RECEIVE);
+      if (sexp_oportp(port))
+        shutdown(sexp_port_sock(port), SD_SEND);
+    }
+    if (!sexp_port_no_closep(port)) {
+      if (--sexp_fileno_count(sexp_port_fd(port)) == 0)
+        sexp_finalize_fileno(ctx, self, n, sexp_port_fd(port));
+    }
+}
+#elif defined(PLAN9)
+#else
     if (sexp_filenop(sexp_port_fd(port))
         && sexp_fileno_openp(sexp_port_fd(port))) {
       if (sexp_port_shutdownp(port)) {
@@ -1668,7 +1684,8 @@ int sexp_buffered_read_char (sexp ctx, sexp p) {
              ? ((unsigned char*)sexp_port_buf(p))[sexp_port_offset(p)++] : EOF);
     }
   } else if (sexp_filenop(sexp_port_fd(p))) {
-    res = read(sexp_port_fileno(p), sexp_port_buf(p) + BUF_START, SEXP_PORT_BUFFER_SIZE - BUF_START);
+    int fd = sexp_port_fileno(p);
+    res = read(fd, sexp_port_buf(p) + BUF_START, SEXP_PORT_BUFFER_SIZE - BUF_START);
     if (res >= 0) {
       sexp_port_offset(p) = BUF_START;
       sexp_port_size(p) = res + BUF_START;
@@ -1966,6 +1983,31 @@ sexp sexp_make_fileno_op (sexp ctx, sexp self, sexp_sint_t n, sexp fd, sexp no_c
     sexp_fileno_fd(res) = sexp_unbox_fixnum(fd);
     sexp_fileno_openp(res) = 1;
     sexp_fileno_no_closep(res) = sexp_truep(no_closep);
+#if SEXP_USE_UNIFY_FILENOS_BY_NUMBER
+    sexp_insert_fileno(ctx, res);
+#endif
+  }
+  sexp_gc_release1(ctx);
+  return res;
+}
+
+sexp sexp_make_fileno_sock (sexp ctx, sexp self, sexp_sint_t fd, SOCKET_TYPE sock) {
+  sexp_gc_var1(res);
+#if SEXP_USE_UNIFY_FILENOS_BY_NUMBER
+  res = sexp_lookup_fileno(ctx, fd);
+  if (sexp_filenop(res)) {
+    sexp_fileno_no_closep(res) = sexp_truep(no_closep);
+    sexp_fileno_openp(res) = 1;  /* not necessarily */
+    return res;
+  }
+#endif
+  sexp_gc_preserve1(ctx, res);
+  res = sexp_alloc_type(ctx, fileno, SEXP_FILENO);
+  if (!sexp_exceptionp(res)) {
+    sexp_fileno_fd(res) = fd;
+    sexp_fileno_openp(res) = 1;
+    sexp_fileno_no_closep(res) = 0;
+    sexp_fileno_sock(res) = sock;
 #if SEXP_USE_UNIFY_FILENOS_BY_NUMBER
     sexp_insert_fileno(ctx, res);
 #endif

--- a/sexp.c
+++ b/sexp.c
@@ -1684,8 +1684,7 @@ int sexp_buffered_read_char (sexp ctx, sexp p) {
              ? ((unsigned char*)sexp_port_buf(p))[sexp_port_offset(p)++] : EOF);
     }
   } else if (sexp_filenop(sexp_port_fd(p))) {
-    int fd = sexp_port_fileno(p);
-    res = read(fd, sexp_port_buf(p) + BUF_START, SEXP_PORT_BUFFER_SIZE - BUF_START);
+    res = read(sexp_port_fileno(p), sexp_port_buf(p) + BUF_START, SEXP_PORT_BUFFER_SIZE - BUF_START);
     if (res >= 0) {
       sexp_port_offset(p) = BUF_START;
       sexp_port_size(p) = res + BUF_START;

--- a/tools/chibi-ffi
+++ b/tools/chibi-ffi
@@ -743,7 +743,7 @@
         ((input-port) "sexp_iportp")
         ((output-port) "sexp_oportp")
         ((input-output-port) "sexp_ioportp")
-        ((fileno fileno-nonblock) "sexp_filenop")
+        ((fileno fileno-nonblock fileno-socket) "sexp_filenop")
         ((uvector) "sexp_uvectorp")
         ((u1vector) "sexp_u1vectorp")
         ((s8vector) "sexp_s8vectorp")
@@ -785,7 +785,7 @@
      ((eq? base 'input-port) "SEXP_IPORT")
      ((eq? base 'output-port) "SEXP_OPORT")
      ((eq? base 'input-output-port) "SEXP_IPORT")
-     ((memq base '(fileno fileno-nonblock)) "SEXP_FILENO")
+     ((memq base '(fileno fileno-nonblock fileno-socket)) "SEXP_FILENO")
      ((uniform-vector-type? base)
       "SEXP_UNIFORM_VECTOR")
      ((void-pointer-type? type) "SEXP_CPOINTER")
@@ -942,6 +942,8 @@
      ((memq base '(fileno fileno-nonblock))
       (cat "(sexp_filenop(" val ") ? sexp_fileno_fd(" val ")"
            " : sexp_unbox_fixnum(" val "))"))
+     ((eq? base 'fileno-socket)
+       (cat "sexp_fileno_sock(" val ")"))
      ((uniform-vector-type? base)
       (cat "((" (uniform-vector-ctype base) ") sexp_uvector_data(" val "))"))
      (else
@@ -964,6 +966,7 @@
     ((string env-string non-null-string bytevector u8vector)
      (if *c++?* "string" "char*"))
     ((fileno fileno-nonblock) "int")
+    (fileno-socket "SOCKET_TYPE")
     ((u1 u8 u16 u32 u64 s8 s16 s32 s64 f8 f16 f32 f64)
      (let ((a
             (uniform-vector-ctype
@@ -1018,7 +1021,7 @@
      ((eq? base 'env-string)
       (cat "(sexp_pairp(" arg ") && sexp_stringp(sexp_car(" arg
            ")) && sexp_stringp(sexp_cdr(" arg ")))"))
-     ((memq base '(fileno fileno-nonblock))
+     ((memq base '(fileno fileno-nonblock fileno-socket))
       (cat "(sexp_filenop(" arg ") || sexp_fixnump(" arg "))"))
      ((string-type? base)
       (cat
@@ -1069,7 +1072,7 @@
           (string-type? base-type)
           (port-type? base-type)
           (uniform-vector-type? base-type)
-          (memq base-type '(bytevector u8vector fileno fileno-nonblock))
+          (memq base-type '(bytevector u8vector fileno fileno-nonblock fileno-socket))
           (and (not array) (eq? 'char base-type)))
       (cat
        "  if (! " (lambda () (check-type arg type)) ")\n"


### PR DESCRIPTION
Support for network on Windows via winsock.

Implementation details:
On Unix sockets are just files, but Windows is a different story, sockets are special type of handles. Sockets-specific calls require such handle. However, Windows provides _open_osfhandle() which wraps socket into file descriptor which supports read() and write() calls. In order to support both socket-specific operations and general I/O operations we need to store both socket and file descriptor. So I've added new field "sock" to fileno. On Windows fd and sock are different, on Unix they are the same.

I've tested my changes via:
1. examples/echo-server-udp.scm
2. a similar single-threaded echo server for tcp which uses ports with read-line and display