### PR TITLE
Install dependencies when installing from file

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -3080,9 +3080,8 @@
             ;; assume certain core libraries already installed
             ;; (info "assuming core library installed: " (car ls))
             (lp (cdr ls) res (cons (car ls) ignored)))
-           ((and (null? candidates) (member (car ls) lib-names))
-            (die 2 "Can't find package: " (car ls)))
-           ((null? candidates)
+           ((or (null? candidates)
+                (and (null? candidates) (member (car ls) lib-names)))
             (cond
              ((yes-or-no? cfg "Can't find package: " (car ls)
                           ".  Proceed anyway?")
@@ -3100,6 +3099,14 @@
             (warn "no candidate selected")
             (lp (cdr ls) res ignored)))))))))
 
+(define (library-in-repository? repo lib-name)
+  (call-with-current-continuation
+    (lambda (return)
+      (for-each (lambda (pkg)
+                  (when (package-provides? pkg lib-name) (return #t)))
+                (cdr repo))
+      #f)))
+
 ;; First lookup dependencies for all implementations so we can
 ;; download in a single batch.  Then perform the installations a
 ;; single implementation at a time.
@@ -3111,19 +3118,31 @@
                            (conf-for-implementation cfg impl))
                          impls))
        ((package-files lib-names) (partition package-file? args))
-       ((lib-names) (map parse-library-name lib-names))
+       ((lib-names)
+        (let ((lib-names (map parse-library-name lib-names)))
+          (when (not (pair? package-files))
+            (for-each
+              (lambda (lib-name)
+                (when (not (library-in-repository? repo lib-name))
+                  (die 2 "Can't find package: " lib-name)))
+              lib-names))
+          lib-names))
+       ((start-dependencies)
+        (lambda (impl cfg)
+          (if (pair? package-files)
+            (apply append
+                   (map (lambda (pkg) (package-dependencies impl cfg pkg))
+                        (map package-file-meta package-files)))
+            lib-names)))
        ((impl-pkgs)
-        (map (lambda (impl cfg)
-               (expand-package-dependencies repo
-                                            impl
-                                            cfg
-                                            (if (pair? package-files)
-                                              (map package-name
-                                                   (map package-file-meta
-                                                        package-files))
-                                              lib-names)))
-             impls
-             impl-cfgs)))
+        (filter-map
+          (lambda (impl cfg)
+            (expand-package-dependencies repo
+                                         impl
+                                         cfg
+                                         (start-dependencies impl cfg)))
+          impls
+          impl-cfgs)))
     (for-each
      (lambda (impl cfg pkgs)
        (when (conf-get cfg 'verbose?)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -3114,7 +3114,14 @@
        ((lib-names) (map parse-library-name lib-names))
        ((impl-pkgs)
         (map (lambda (impl cfg)
-               (expand-package-dependencies repo impl cfg lib-names))
+               (expand-package-dependencies repo
+                                            impl
+                                            cfg
+                                            (if (pair? package-files)
+                                              (map package-name
+                                                   (map package-file-meta
+                                                        package-files))
+                                              lib-names)))
              impls
              impl-cfgs)))
     (for-each


### PR DESCRIPTION
When installing package from file also install it's dependencies. Fix for https://github.com/ashinn/chibi-scheme/issues/1093

I had to move the immediate fail when package does not exist from `expand-package-dependencies` into `command/install`. So that when given nonexisting package as argument the fail is immediate, but when dependency does not exist user is prompted to continue.

```
snow-chibi install --impls=chibi lol.lel
WARNING: snow config file not found: : "/home/retropikzel/.snow/config.scm"
Can't find package: (lol lel)
```

From the issue.

main.scm:
```
(import (scheme base)
        (scheme write)
        (foo bar))
(hello)
```

foo/bar.sld:
```
(define-library
  (foo bar)
  (import (scheme base)
          (retropikzel hello))
  (export hello))
```

```
snow-chibi package foo/bar.sld
snow-chibi install --impls=chibi foo-bar.tgz
chibi-scheme main.scm
Hello
```


Add nonexisting dependency to foo/bar.sld:
```
(define-library
  (foo bar)
  (import (scheme base)
          (does not exist)
          (retropikzel hello))
  (export hello))
```

```
snow-chibi package foo/bar.sld
snow-chibi install --impls=chibi foo-bar.tgz
WARNING: skipping already installed library: : (scheme base)
Can't find package: (does not exist).  Proceed anyway? [y/n]: 
```

Currently it will output extra warnings for `(scheme ...)` libraries. This is because another bug. Related to `implementation-supports-natively?` and checks. Which I plan to fix next.