### PR TITLE
Fixed retrieval of socket from fileno

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SNOW_CHIBI ?= tools/snow-chibi
 ########################################################################
 
 CHIBI_COMPILED_LIBS = lib/chibi/filesystem$(SO) lib/chibi/weak$(SO) \
-        lib/chibi/net$(SO) \
+	lib/chibi/net$(SO) \
 	lib/chibi/heap-stats$(SO) lib/chibi/disasm$(SO) lib/chibi/ast$(SO) \
 	lib/chibi/json$(SO) lib/chibi/emscripten$(SO)
 CHIBI_POSIX_COMPILED_LIBS = lib/chibi/process$(SO) lib/chibi/time$(SO) \

--- a/Makefile.detect
+++ b/Makefile.detect
@@ -192,7 +192,7 @@ endif
 
 CHIBI_POSIX_COMPILED_LIBS = lib/chibi/process$(SO) lib/chibi/time$(SO) \
 	lib/chibi/system$(SO) lib/chibi/stty$(SO) lib/chibi/pty$(SO) \
-	lib/chibi/net$(SO) lib/srfi/18/threads$(SO)
+	lib/srfi/18/threads$(SO)
 CHIBI_WIN32_COMPILED_LIBS = lib/chibi/win32/process-win32$(SO)
 
 ifndef EXCLUDE_POSIX_LIBS

--- a/include/chibi/sexp.h
+++ b/include/chibi/sexp.h
@@ -1277,7 +1277,7 @@ enum sexp_uniform_vector_type {
 #ifdef _WIN32
 #define sexp_fileno_sock(f)      (sexp_pred_field(f, fileno, sexp_filenop, sock))
 #else
-#define sexp_fileno_sock(f)      (sexp_port_fd(f))
+#define sexp_fileno_sock(f)      (sexp_fileno_fd(f))
 #endif
 #define sexp_fileno_no_closep(f) (sexp_pred_field(f, fileno, sexp_filenop, no_closep))
 


### PR DESCRIPTION
It was tricky to test: these defines are used as left side in assignments and as right side in retrievals. So in UDP echo server a socket fd value was written instead of fileno pointer, and this value was later retrieved during send() and receive(), which worked as long as no other fields were written/read.