### PR TITLE
srfi 18: time->seconds does not round to nearest second, returns exact

### DIFF
--- a/lib/srfi/18/interface.scm
+++ b/lib/srfi/18/interface.scm
@@ -3,10 +3,15 @@
 (define (time? x) (timeval? (if (pair? x) (car x) x)))
 
 (define (time->seconds x)
-  (timeval-seconds (if (pair? x) (car x) x)))
+  (let ((t (if (pair? x) (car x) x)))
+    (+ (timeval-seconds t)
+       (* 1e-6 (timeval-microseconds t)))))
 
 (define (seconds->time x)
-  (make-timeval (if (inexact? x) (inexact->exact (round x)) x) 0))
+  (if (integer? x)
+      (make-timeval x 0)
+      (let ((x0 (floor x)))
+        (make-timeval x0 (* 1e6 (- x x0))))))
 
 (define (timeout->seconds x)
   (if (time? x) (- (time->seconds x) (time->seconds (current-time))) x))


### PR DESCRIPTION
The implementation of time->seconds rounds the representation of the `time?` to the nearest second. The srfi seems pretty clear that this isn't the intended behavior:

```
(time->seconds time)                                  ;procedure
Converts the time object time into an exact or inexact real number representing the number of seconds elapsed since some implementation dependent reference point.

    (time->seconds (current-time))  ==>  955039784.928075   ;; <------
```

It also makes the srfi's interface unusable for timeouts <1s, which is goofy.

My change does the obvious thing. It uses an exact (rational) representation for microseconds, because I think that `(seconds->time (time->seconds T))` should equal `T`. That said, using an inexact? to match `current-second` from `(scheme time)` seems tasteful as well.