### PR TITLE
use monotonic, higher resolution jiffies

### DIFF
--- a/lib/scheme/time.c
+++ b/lib/scheme/time.c
@@ -119,9 +119,9 @@ sexp sexp_current_jiffy (sexp ctx, sexp self, sexp_sint_t n) {
 #if SEXP_MS_JIFFY
   LARGE_INTEGER frequency;
   QueryPerformanceFrequency(&frequency);
-  return sexp_make_fixnum((1000*t)/frequency);
+  return sexp_make_fixnum((1000*t.QuadPart)/frequency.QuadPart);
 #else
-  return sexp_make_fixnum(t);
+  return sexp_make_fixnum(t.QuadPart);
 #endif
 
 #elif !defined(PLAN9)
@@ -157,7 +157,7 @@ sexp sexp_jiffies_per_second(sexp ctx, sexp self, sexp_sint_t n) {
 #ifdef _WIN32
   LARGE_INTEGER frequency;
   QueryPerformanceFrequency(&frequency);
-  return sexp_make_fixnum(frequency);
+  return sexp_make_fixnum(frequency.QuadPart);
 #elif !defined(PLAN9)
   return sexp_make_fixnum(1000000000);
 #else

--- a/lib/scheme/time.c
+++ b/lib/scheme/time.c
@@ -4,12 +4,15 @@
 /* BSD-style license: http://synthcode.com/license.txt       */
 
 #include <chibi/eval.h>
+#include <chibi/sexp.h>
+#include <stdint.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #elif !defined(PLAN9)
 #include <sys/time.h>
+#include <time.h>
 #else
 typedef long time_t;
 #endif
@@ -49,10 +52,10 @@ static void current_ntp_clock_values (double *second, int *leap_second_indicator
   struct ntptimeval ntv;
   int status = ntp_gettime(&ntv);
   if (ntp_resolution != 0 && (
-        status == TIME_OK  || 
-        status == TIME_INS || 
-        status == TIME_DEL || 
-        status == TIME_OOP || 
+        status == TIME_OK  ||
+        status == TIME_INS ||
+        status == TIME_DEL ||
+        status == TIME_OOP ||
         status == TIME_WAIT)) {
     if (ntp_resolution == 1e-6) {
       struct timeval *tv = (struct timeval *) &ntv.time;
@@ -108,11 +111,44 @@ sexp sexp_current_clock_second (sexp ctx, sexp self, sexp_sint_t n) {
 #endif
 }
 
+sexp sexp_current_jiffy (sexp ctx, sexp self, sexp_sint_t n) {
+#ifdef _WIN32
+  LARGE_INTEGER t;
+  QueryPerformanceCounter(&t);
+  return sexp_make_fixnum(t);
+#elif !defined(PLAN9)
+  struct timespec tv;
+  int err = clock_gettime(CLOCK_MONOTONIC, &tv);
+  // :note could use errno, here
+  if (err)
+    return sexp_user_exception(ctx, self, "couldn't get current jiffy", SEXP_FALSE);
+  return sexp_make_fixnum(1000000000*tv.tv_sec + tv.tv_nsec);
+#else
+  // :note plan9 has `cycles`, but converting that to a clock is non-trivial
+  vlong res = nsec(NULL);
+  return sexp_make_fixnum(res);
+#endif
+}
+
+sexp sexp_jiffies_per_second(sexp ctx, sexp self, sexp_sint_t n) {
+#ifdef _WIN32
+  LARGE_INTEGER frequency;
+  QueryPerformanceFrequency(&frequency);
+  return sexp_make_fixnum(frequency);
+#elif !defined(PLAN9)
+  return sexp_make_fixnum(1000000000);
+#else
+  return sexp_make_fixnum(1000000000);
+#endif
+}
+
 sexp sexp_init_library (sexp ctx, sexp self, sexp_sint_t n, sexp env, const char* version, const sexp_abi_identifier_t abi) {
   if (!(sexp_version_compatible(ctx, version, sexp_version)
         && sexp_abi_compatible(ctx, abi, SEXP_ABI_IDENTIFIER)))
     return sexp_global(ctx, SEXP_G_ABI_ERROR);
   sexp_define_foreign(ctx, env, "current-clock-second", 0, sexp_current_clock_second);
+  sexp_define_foreign(ctx, env, "current-jiffy", 0, sexp_current_jiffy);
+  sexp_define_foreign(ctx, env, "jiffies-per-second", 0, sexp_jiffies_per_second);
 #if SEXP_USE_NTP_GETTIME
   determine_ntp_resolution();
   sexp_define_foreign(ctx, env, "current-ntp-clock-values", 0, sexp_current_ntp_clock_values);

--- a/lib/scheme/time.c
+++ b/lib/scheme/time.c
@@ -123,31 +123,25 @@ sexp sexp_current_jiffy (sexp ctx, sexp self, sexp_sint_t n) {
 #else
   return sexp_make_fixnum(t.QuadPart);
 #endif
-
-#elif !defined(PLAN9)
+#else // _WIN32
+#if !defined(PLAN9)
   struct timespec tv;
   int err = clock_gettime(CLOCK_MONOTONIC, &tv);
   // :note could use errno, here
   if (err)
     return sexp_user_exception(ctx, self, "couldn't get current jiffy", SEXP_FALSE);
   uint64_t current_ns = 1000000000*tv.tv_sec + tv.tv_nsec;
-#if SEXP_MS_JIFFY
-  uint32_t current_ms = current_ns / 1000000;
-  return sexp_make_fixnum(current_ms);
-#else
-  return sexp_make_fixnum(current_ns);
-#endif
-
 #else
   // :note plan9 has `cycles`, but converting that to a clock is non-trivial
   uint64_t current_ns = nsec(NULL);
+#endif
 #if SEXP_MS_JIFFY
   uint32_t current_ms = current_ns / 1000000;
   return sexp_make_fixnum(current_ms);
 #else
   return sexp_make_fixnum(current_ns);
 #endif
-#endif
+#endif // _WIN32
 }
 
 sexp sexp_jiffies_per_second(sexp ctx, sexp self, sexp_sint_t n) {
@@ -158,8 +152,6 @@ sexp sexp_jiffies_per_second(sexp ctx, sexp self, sexp_sint_t n) {
   LARGE_INTEGER frequency;
   QueryPerformanceFrequency(&frequency);
   return sexp_make_fixnum(frequency.QuadPart);
-#elif !defined(PLAN9)
-  return sexp_make_fixnum(1000000000);
 #else
   return sexp_make_fixnum(1000000000);
 #endif

--- a/lib/scheme/time.c
+++ b/lib/scheme/time.c
@@ -111,26 +111,49 @@ sexp sexp_current_clock_second (sexp ctx, sexp self, sexp_sint_t n) {
 #endif
 }
 
+#define SEXP_MS_JIFFY !SEXP_64_BIT
 sexp sexp_current_jiffy (sexp ctx, sexp self, sexp_sint_t n) {
 #ifdef _WIN32
   LARGE_INTEGER t;
   QueryPerformanceCounter(&t);
+#if SEXP_MS_JIFFY
+  LARGE_INTEGER frequency;
+  QueryPerformanceFrequency(&frequency);
+  return sexp_make_fixnum((1000*t)/frequency);
+#else
   return sexp_make_fixnum(t);
+#endif
+
 #elif !defined(PLAN9)
   struct timespec tv;
   int err = clock_gettime(CLOCK_MONOTONIC, &tv);
   // :note could use errno, here
   if (err)
     return sexp_user_exception(ctx, self, "couldn't get current jiffy", SEXP_FALSE);
-  return sexp_make_fixnum(1000000000*tv.tv_sec + tv.tv_nsec);
+  uint64_t current_ns = 1000000000*tv.tv_sec + tv.tv_nsec;
+#if SEXP_MS_JIFFY
+  uint32_t current_ms = current_ns / 1000000;
+  return sexp_make_fixnum(current_ms);
+#else
+  return sexp_make_fixnum(current_ns);
+#endif
+
 #else
   // :note plan9 has `cycles`, but converting that to a clock is non-trivial
-  vlong res = nsec(NULL);
-  return sexp_make_fixnum(res);
+  uint64_t current_ns = nsec(NULL);
+#if SEXP_MS_JIFFY
+  uint32_t current_ms = current_ns / 1000000;
+  return sexp_make_fixnum(current_ms);
+#else
+  return sexp_make_fixnum(current_ns);
+#endif
 #endif
 }
 
 sexp sexp_jiffies_per_second(sexp ctx, sexp self, sexp_sint_t n) {
+#if SEXP_MS_JIFFY
+    return sexp_make_fixnum(1000);
+#else
 #ifdef _WIN32
   LARGE_INTEGER frequency;
   QueryPerformanceFrequency(&frequency);
@@ -139,6 +162,7 @@ sexp sexp_jiffies_per_second(sexp ctx, sexp self, sexp_sint_t n) {
   return sexp_make_fixnum(1000000000);
 #else
   return sexp_make_fixnum(1000000000);
+#endif
 #endif
 }
 

--- a/lib/scheme/time.sld
+++ b/lib/scheme/time.sld
@@ -72,7 +72,4 @@
 
     ;; Exported interface.
     (define current-second
-      (make-tai-clock clock-type call-with-current-clock-values))
-    (define (current-jiffy)
-      (inexact->exact (round (* (current-second) (jiffies-per-second)))))
-    (define (jiffies-per-second) 1000)))
+      (make-tai-clock clock-type call-with-current-clock-values))))


### PR DESCRIPTION
The current-jiffy was 1:1 with current-second, but assuming that its meant to be used more for measuring intervals and not wall time, I replaced it with more suitable clocks:

1. posix uses [CLOCK_MONOTONIC](https://www.man7.org/linux/man-pages/man3/clock_gettime.3.html). an argument could be made for CLOCK_MONOTONIC_RAW on linux.
2. windows uses [QueryPerformanceCounter](https://learn.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter)
3. plan9 keep using `nsec`. they have [`cycles`](https://github.com/brho/plan9/blob/master/sys/include/libc.h#L345), but its not a clock out of the box. 

I haven't tested the windows or plan9 code, but it looks sane to me. Advice on cross-compiling from linux to windows appreciated. I couldn't bring myself to install mingw under wine, but I also couldn't get `make CC=mingw... PLATFORM=windows` to Just Work.