### PR TITLE
Fix broken Makefile-based Emscripten builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,9 @@ init-dev:
 
 js: js/chibi.js
 
-js/chibi.js: chibi-scheme-emscripten chibi-scheme-static.o js/pre.js js/post.js js/exported_functions.json
-	emcc -O0 chibi-scheme-static.o -o $@ -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s EXPORT_NAME=\"Chibi\" -s EXPORTED_FUNCTIONS=@js/exported_functions.json `find  lib -type f \( -name "*.scm" -or -name "*.sld" \) | awk '{ printf " --preload-file %s", $$1 }'` -s 'EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]' --pre-js js/pre.js --post-js js/post.js
-
-chibi-scheme-static.o:
-	emmake $(MAKE) PLATFORM=emscripten CHIBI_DEPENDENCIES= CHIBI="CHIBI_IGNORE_SYSTEM_PATH=1 CHIBI_MODULE_PATH=lib ./chibi-scheme-emscripten" FEATURES="--features chibi,threads,emscripten,wasm32,little-endian" PREFIX= CFLAGS=-O2 SEXP_USE_DL=0 EXE=.o SO=.o STATICFLAGS=-shared CPPFLAGS="-DSEXP_USE_STRICT_TOPLEVEL_BINDINGS=1 -DSEXP_USE_ALIGNED_BYTECODE=1 -DSEXP_USE_STATIC_LIBS=1 -DSEXP_USE_STATIC_LIBS_NO_INCLUDE=0" clibs.c chibi-scheme-static.o VERBOSE=1
+js/chibi.js: chibi-scheme-emscripten js/pre.js js/post.js js/exported_functions.json
+	emmake $(MAKE) PLATFORM=emscripten CHIBI_DEPENDENCIES= CHIBI="CHIBI_IGNORE_SYSTEM_PATH=1 CHIBI_MODULE_PATH=lib ./chibi-scheme-emscripten" FEATURES="--features chibi,threads,emscripten,wasm32,little-endian" PREFIX= CFLAGS=-O2 SEXP_USE_DL=0 CPPFLAGS="-DSEXP_USE_STRICT_TOPLEVEL_BINDINGS=1 -DSEXP_USE_ALIGNED_BYTECODE=1 -DSEXP_USE_STATIC_LIBS=1 -DSEXP_USE_STATIC_LIBS_NO_INCLUDE=0" clibs.c libchibi-scheme.a main.o VERBOSE=1
+	emcc -O0 libchibi-scheme.a main.o -o $@ -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s EXPORT_NAME=\"Chibi\" -s EXPORTED_FUNCTIONS=@js/exported_functions.json `find  lib -type f \( -name "*.scm" -or -name "*.sld" \) | awk '{ printf " --preload-file %s", $$1 }'` -s 'EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]' --pre-js js/pre.js --post-js js/post.js
 
 chibi-scheme-emscripten: VERSION
 	$(MAKE) distclean

--- a/main.c
+++ b/main.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2009-2015 Alex Shinn.  All rights reserved. */
 /* BSD-style license: http://synthcode.com/license.txt       */
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
 
@@ -296,7 +296,7 @@ static void do_init_context (sexp* ctx, sexp* env, sexp_uint_t heap_size,
     } while (0)
 
 /* static globals for the sake of resuming from within emscripten */
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 static sexp sexp_resume_ctx = SEXP_FALSE;
 static sexp sexp_resume_proc = SEXP_FALSE;
 #endif
@@ -640,7 +640,7 @@ sexp run_main (int argc, char **argv) {
 #if SEXP_USE_WARN_UNDEFS
         sexp_warn_undefs(ctx, env, tmp, SEXP_VOID);
 #endif
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         if (sexp_applicablep(tmp)) {
           sexp_resume_ctx = ctx;
           sexp_resume_proc = tmp;
@@ -671,7 +671,7 @@ sexp run_main (int argc, char **argv) {
   return res;
 }
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 void sexp_resume() {
   sexp_gc_var1(tmp);
   sexp_gc_preserve1(sexp_resume_ctx, tmp);


### PR DESCRIPTION
With these changes, "make js" now works with the current release of emsdk. Fixes #1139.