### PR TITLE
Add check-impl? from SRFI 273 to SRFI 253 code

### DIFF
--- a/lib/srfi/253.sld
+++ b/lib/srfi/253.sld
@@ -2,8 +2,10 @@
   (import (scheme base)
           (scheme case-lambda)
           (scheme list)
-          (chibi assert))
-  (export check-arg values-checked
+          (chibi assert)
+          (chibi ast))
+  (export check-impl?
+          check-arg values-checked
           check-case
           lambda-checked define-checked
           case-lambda-checked

--- a/lib/srfi/253/impl.scm
+++ b/lib/srfi/253/impl.scm
@@ -22,6 +22,10 @@
 ;;; FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 ;;; OTHER DEALINGS IN THE SOFTWARE.
 
+(define (check-impl? type)
+  (lambda (x)
+    (eq? type (type-of x))))
+
 (define-syntax check-arg
   (syntax-rules ()
     ((_ pred val caller)


### PR DESCRIPTION
While SRFI 273 is not yet finalized, its [check-impl? part](https://srfi.schemers.org/srfi-273/srfi-273.html#spec--check-impl) is likely to be finalized unaltered, because implementation-specific type checking is important.

Thus this pull request adding `check-impl?` as a procedure checking the type of the argument. No syntax required, as type checking is runtime and not compile-time.