### PR TITLE
Snow chibi list all

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1309,7 +1309,7 @@
     (if sexp? (display ")"))
     (newline)))
 
-(define (command/show cfg spec)
+(define (command/show cfg spec . args)
   (current-repositories cfg)
   (let* ((impls (conf-selected-implementations cfg))
          (impl-cfgs (map (lambda (impl)

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1261,6 +1261,38 @@
      (else
       (display "No libraries matched your query.\n")))))
 
+(define (all-packages repositories)
+  (filter
+    (lambda (item)
+      (if (and (list? item) (equal? (car item) 'package)) item #f))
+    repositories))
+
+(define (command/list-all cfg spec . args)
+  (let* ((repositories (current-repositories cfg))
+         (sexp? (conf-get cfg 'sexp?))
+         (separator (conf-get cfg 'separator " "))
+         (name->dotted
+           (lambda (name)
+             (string-join
+               (map (lambda (item)
+                      (cond ((symbol? item) (symbol->string item))
+                            ((number? item) (number->string item))
+                            (else (error "Unknown type in library name" name))))
+                    name)
+               ".")))
+         (names (map package-name (all-packages repositories))))
+    (when sexp? (display "("))
+    (for-each
+      (lambda (name)
+        (if (conf-get cfg 'dotted-format?)
+          (display (name->dotted name))
+          (display name))
+        (display separator))
+      names)
+    (when sexp? (display ")"))
+    (newline)))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Show - show detailed information for the given libraries
 ;;
@@ -1277,7 +1309,7 @@
     (if sexp? (display ")"))
     (newline)))
 
-(define (command/show cfg spec . args)
+(define (command/show cfg spec)
   (current-repositories cfg)
   (let* ((impls (conf-selected-implementations cfg))
          (impl-cfgs (map (lambda (impl)

--- a/lib/chibi/snow/commands.sld
+++ b/lib/chibi/snow/commands.sld
@@ -13,6 +13,7 @@
           command/install-dependencies
           command/remove
           command/search
+          command/list-all
           command/show
           command/status
           command/srfi-list

--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -95,7 +95,8 @@
     (foreign-depends (list string) "foreign libraries library depends on")
     (use-curl? boolean ("use-curl") "use curl for file uploads")
     (sexp? boolean ("sexp") "output information in sexp format")
-    ))
+    (dotted-format? boolean "output the package names in dotted format")
+    (separator string "string to separate package names with, defaults to space")))
 
 (define (conf-default-path name)
   (or (get-environment-variable "SNOW_CHIBI_CONFIG")
@@ -105,6 +106,13 @@
 
 (define search-spec '())
 (define show-spec '())
+(define list-all-spec
+  '((dotted-format? boolean
+                   ("dotted-format")
+                   "output the package names in dotted format")
+    (sexp? boolean ("sexp") "output the package names as sexp")
+    (separator string
+               "string to separate package names with, defaults to space")))
 (define install-spec
   '((skip-tests? boolean ("skip-tests") "don't run tests even if present")
     (show-tests? boolean ("show-tests") "show test output even on success")
@@ -156,8 +164,7 @@
     (test-library sexp)
     (sig-file existing-filename)
     (output filename)
-    (output-dir dirname)
-    ))
+    (output-dir dirname)))
 (define upload-spec
   `((uri string)
     ,@package-spec))
@@ -180,6 +187,9 @@
      (search
       "search for packages"
       (@ ,@search-spec) (,command/search terms ...))
+     (list-all
+      "list all packages"
+      (@ ,@list-all-spec) (,command/list-all))
      (show
       "show package descriptions"
       (@ ,@show-spec) (,command/show names ...))


### PR DESCRIPTION
Adds a list-all command to snow-chibi. It has options:

- --sexp?
  - Output as Scheme readable s-expression
- --dotted-format?
  - Library names in dotted format, (retropikzel tap) -> retropikzel.tap
- --separator
  - Set the separator for library list items

Examples:
```
snow-chibi list-all
> (retropikzel tap) (srfi 170) (retropikzel compile-r7rs)...
snow-chibi -sexp?=1 list-all
> ((retropikzel tap) (srfi 170) (retropikzel compile-r7rs)...)
snow-chibi --dotted-format list-all
> retropikzel.tap srfi.170 retropikzel.compile-r7rs...
snow-chibi --sexp?=1 --dotted-format?=1 list-all
> (retropikzel.tap srfi.170 retropikzel.compile-r7rs...)
snow-chibi --separator="___" list-all
> (retropikzel tap)___(srfi 170)___(retropikzel compile-r7rs)...