### PR TITLE
Fix some return type patterns in SRFI 253 lambda-checked

### DIFF
--- a/lib/srfi/253/impl.scm
+++ b/lib/srfi/253/impl.scm
@@ -92,11 +92,21 @@
       (args ... . last) (checks ...)))))
 
 (define-syntax lambda-checked
-  (syntax-rules ()
+  (syntax-rules (=>)
+    ;; Empty args with return type checking
+    ((_ () => (returns ...) body ...)
+     (lambda ()
+       (values-checked (returns ...) (begin body ...))))
+    ;; No need to parse as there are no args
     ((_ () body ...)
      (lambda () body ...))
+    ;; Regular (positional ... [. rest]) arglist
     ((_ (arg . args) body ...)
      (%lambda-checked lambda-checked (body ...) () () arg . args))
+    ;; arg->list lambda, but with return checking
+    ((_ arg => (returns ...) body ...)
+     (lambda arg
+       (values-checked (returns ...) (begin body ...))))
     ;; Case of arg->list lambda, no-op.
     ((_ arg body ...)
      (lambda arg body ...))))

--- a/lib/srfi/253/test.sld
+++ b/lib/srfi/253/test.sld
@@ -127,7 +127,12 @@
         (test-assert (lambda-checked (a . c) #t))
         (test-assert (lambda-checked ((a integer?) . c) #t))
         (test-assert (lambda-checked (a b . c) #t))
-        (test-assert (lambda-checked (a (b integer?) . c) #t)))
+        (test-assert (lambda-checked (a (b integer?) . c) #t))
+        ;; SRFI 273 return type checks
+        (test-assert ((lambda-checked ((b integer?)) => (integer?) 2) 1))
+        (test-error ((lambda-checked ((b integer?)) => (integer?) #t) 1))
+        (test-error ((lambda-checked () => (integer?) #t)))
+        (test-error ((lambda-checked args => (integer?) #t) 1 2 3)))
 
 
       (test-group "case-lambda-checked"


### PR DESCRIPTION
Previously, this failed on `(lambda () => (type) ...)` and `(lambda rest-arg => (type) ...)`