### PR TITLE
Allow variadic generics

### DIFF
--- a/lib/chibi/generic-test.sld
+++ b/lib/chibi/generic-test.sld
@@ -33,5 +33,24 @@
         (test 21.0 (mul 3.0 7))
         (test 21.0 (mul 3 7.0))
         (test 21.1 (mul 3.0 7.0)))
+      ;; Variadic methods
+      (let ()
+        (define-generic var)
+        (define-method (var (x number?) (y number?))
+          (list x y))
+        (test '(3 7) (var 3 7))
+        ;; Predicate mismatch
+        (test-error (var "hello" 1))
+        (test-error (var 1 "hello"))
+        ;; Variadic behavior unimplemented yet
+        (test-error (var 1 2 3))
+        (test-error (var))
+        (define-method (var . rest)
+          'variadic)
+        (test 'variadic (var))
+        (test 'variadic (var 1))
+        (test 'variadic (var 1 2 3 4))
+        ;; Required arg methods prevail
+        (test '(3 7) (var 3 7)))
 
       (test-end))))

--- a/lib/chibi/generic.scm
+++ b/lib/chibi/generic.scm
@@ -32,15 +32,26 @@
   (er-macro-transformer
    (lambda (e r c)
      (let ((name (car (cadr e)))
-           (params (map (lambda (param)
-                          (if (identifier? param)
-                              `(,param (lambda _ #t))
-                              param))
-                        (cdr (cadr e))))
+           (params (let lp ((params (cdr (cadr e))))
+                     (cond
+                      ((not (pair? params)) '())
+                      ((identifier? (car params))
+                       (cons `(,(car params) (lambda _ #t))
+                             (lp (cdr params))))
+                      (else
+                       (cons (car params) (lp (cdr params)))))))
+           (variadic? (let lp ((params (cdr (cadr e))))
+                        (cond
+                         ((pair? params) (lp (cdr params)))
+                         ((null? params) #f)
+                         (else params))))
            (body (cddr e)))
        `(,(r 'generic-add!) ,name
          (,(r 'list) ,@(map cadr params))
-         (,(r 'lambda) (,(r 'next) ,@(map car params))
+         ',variadic?
+         (,(r 'lambda) ,@(if variadic?
+                             `((,(r 'next) ,@(map car params) . ,variadic?))
+                             `((,(r 'next) ,@(map car params))))
           (,(r 'let-syntax) ((call-next-method
                               (,(r 'syntax-rules) ()
                                ((_) (,(r 'next))))))
@@ -59,26 +70,58 @@
 
 ;;> Create a new first-class generic function named \var{name}.
 
+(define (sublist lst capped-length)
+  (cond
+   ((null? lst)
+    '())
+   ((zero? capped-length)
+    '())
+   (else
+    (cons (car lst)
+          (sublist (cdr lst) (- capped-length 1))))))
+
 (define (make-generic name)
   (let ((name name)
-        (methods (make-vector 6 '())))
+        (methods (make-vector 6 '()))
+        (variadic-methods (make-vector 6 '())))
     (vector-set! methods
-                 3
+                 4
                  (list (cons (list (lambda (x) (eq? x add-method-tag))
                                    (lambda (x) (list? x))
+                                   (lambda (x) (or (boolean? x)
+                                                   (symbol? x)))
                                    procedure?)
-                             (lambda (next t p f)
-                               (set! methods (insert-method! methods p f))))))
+                             (lambda (next t preds rest? func)
+                               (if rest?
+                                   (set! variadic-methods (insert-method! variadic-methods preds func))
+                                   (set! methods (insert-method! methods preds func)))))))
     (lambda args
-      (let ((len (length args)))
+      (letrec* ((len (length args))
+                (search-variadic
+                 (lambda (idx)
+                   (cond
+                    ((> idx len)
+                     (no-applicable-method-error name args))
+                    (else
+                     (let search-matching ((checks+fns (vector-ref variadic-methods idx)))
+                       (cond
+                        ((null? checks+fns)
+                         (search-variadic (+ 1 idx)))
+                        ((satisfied? (caar checks+fns)
+                                     (sublist args idx))
+                         (apply (cdar checks+fns)
+                                (lambda () (search-matching (cdr checks+fns)))
+                                args))
+                        (else
+                         (search-matching (cdr checks+fns))))))))))
         (cond
          ((>= len (vector-length methods))
-          (no-applicable-method-error name args))
+          (search-variadic 0))
          (else
           (let lp ((ls (vector-ref methods len)))
             (cond
              ((null? ls)
-              (no-applicable-method-error name args))
+              (search-variadic 0))
              ((satisfied? (car (car ls)) args)
               (apply (cdr (car ls)) (lambda () (lp (cdr ls))) args))
              (else
@@ -100,5 +143,5 @@
 ;;> that applies when all parameters match the given list
 ;;> of predicates \var{preds}.
 
-(define (generic-add! g preds f)
-  (g add-method-tag preds f))
+(define (generic-add! g preds variadic? func)
+  (g add-method-tag preds variadic? func))

--- a/lib/chibi/generic.scm
+++ b/lib/chibi/generic.scm
@@ -70,15 +70,15 @@
 
 ;;> Create a new first-class generic function named \var{name}.
 
-(define (sublist lst capped-length)
+(define (take n lst)
   (cond
-   ((null? lst)
+   ((not (pair? lst))
     '())
-   ((zero? capped-length)
+   ((zero? n)
     '())
    (else
     (cons (car lst)
-          (sublist (cdr lst) (- capped-length 1))))))
+          (take (- n 1) (cdr lst))))))
 
 (define (make-generic name)
   (let ((name name)
@@ -87,7 +87,7 @@
     (vector-set! methods
                  4
                  (list (cons (list (lambda (x) (eq? x add-method-tag))
-                                   (lambda (x) (list? x))
+                                   list?
                                    (lambda (x) (or (boolean? x)
                                                    (symbol? x)))
                                    procedure?)
@@ -108,7 +108,7 @@
                         ((null? checks+fns)
                          (search-variadic (+ 1 idx)))
                         ((satisfied? (caar checks+fns)
-                                     (sublist args idx))
+                                     (take idx args))
                          (apply (cdar checks+fns)
                                 (lambda () (search-matching (cdr checks+fns)))
                                 args))
@@ -139,9 +139,10 @@
       (vector-set! res plen (cons (cons preds f) (vector-ref res plen)))
       res)))
 
-;;> Extend the generic \var{g} with a new method \var{f}
+;;> Extend the generic \var{g} with a new method \var{func}
 ;;> that applies when all parameters match the given list
-;;> of predicates \var{preds}.
+;;> of predicates \var{preds}, or if `variadic?` is true a prefix
+;;> of the parameters matches \var{preds}.
 
 (define (generic-add! g preds variadic? func)
   (g add-method-tag preds variadic? func))

--- a/lib/chibi/generic.scm
+++ b/lib/chibi/generic.scm
@@ -40,17 +40,17 @@
                              (lp (cdr params))))
                       (else
                        (cons (car params) (lp (cdr params)))))))
-           (variadic? (let lp ((params (cdr (cadr e))))
-                        (cond
-                         ((pair? params) (lp (cdr params)))
-                         ((null? params) #f)
-                         (else params))))
+           (rest-param (let lp ((params (cdr (cadr e))))
+                         (cond
+                          ((pair? params) (lp (cdr params)))
+                          ((null? params) #f)
+                          (else params))))
            (body (cddr e)))
        `(,(r 'generic-add!) ,name
          (,(r 'list) ,@(map cadr params))
-         ',variadic?
-         (,(r 'lambda) ,@(if variadic?
-                             `((,(r 'next) ,@(map car params) . ,variadic?))
+         ',rest-param
+         (,(r 'lambda) ,@(if rest-param
+                             `((,(r 'next) ,@(map car params) . ,rest-param))
                              `((,(r 'next) ,@(map car params))))
           (,(r 'let-syntax) ((call-next-method
                               (,(r 'syntax-rules) ()

--- a/lib/chibi/generic.scm
+++ b/lib/chibi/generic.scm
@@ -100,7 +100,8 @@
                 (search-variadic
                  (lambda (idx)
                    (cond
-                    ((> idx len)
+                    ((or (> idx len)
+                         (>= idx (vector-length variadic-methods)))
                      (no-applicable-method-error name args))
                     (else
                      (let search-matching ((checks+fns (vector-ref variadic-methods idx)))

--- a/lib/srfi/253/test.sld
+++ b/lib/srfi/253/test.sld
@@ -24,8 +24,7 @@
       (define-checked (d (a integer?)) #t)
       (define-checked (e b) #t)
       (define-checked (f (b string?)) #t)
-      ;; TODO: Uncomment when generics support rest args
-      ;; (define-checked (g b . d) #t)
+      (define-checked (g b . d) #t)
       (define-checked h string? "hello")
       (define-record-type-checked <test>
         (make-test a b)
@@ -176,10 +175,9 @@
         (test-error (e 1 2 3))
         (test-assert (f "hello"))
         (test-error (f 3))
-        ;; TODO: Uncomment when generics support rest args
-        ;; (test-assert (g 1))
-        ;; (test-assert (g 1 2))
-        ;; (test-assert (g 1 2 3))
+        (test-assert (g 1))
+        (test-assert (g 1 2))
+        (test-assert (g 1 2 3))
         (test-assert h)
         (set! h "whatever")
         (test-assert h))


### PR DESCRIPTION
This allows defining variadic generics, bridging a previously puzzling gap between regular procedures and generics. This incurs a search cost. Technically quadratic, practically negligible (I doubt anyone defines as many methods as necessary to make this stutter.)