### PR TITLE
Message when installing library and it has no tests

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1900,6 +1900,8 @@
           (yes-or-no? cfg "Tests failed: " test-file
                       " (details in " dir "/test-{out,err}.txt)\n"
                       "Proceed anyway?")))
+     ((not test-file)
+      (info "Library has no tests."))
      (else
       #t))))
 


### PR DESCRIPTION
The branch is very poorly named. But basically when checking the test output with automation this helps. When the tests all have passed the output will contain text "All tests passed.", when the library has not tests it will contain text "Library has no tests.".

Often when library has no tests the output is not empty, usually there is atleast one  `WARNING: skipping already installed library: : <some library>`

If you do not like it I can move it behind the `verbose?` flag.