### PR TITLE
Generate cut-created procedures with a %cut% as the name

### DIFF
--- a/lib/srfi/26.sld
+++ b/lib/srfi/26.sld
@@ -6,7 +6,8 @@
    (define-syntax %cut
      (syntax-rules (<> <...>)
        ((%cut e? params args)
-        (lambda params args))
+        (let ((%cut% (lambda params args)))
+          %cut%))
        ((%cut e? (params ...) (args ...) <> . rest)
         (%cut e? (params ... tmp) (args ... tmp) . rest))
        ((%cut e? (params ...) (args ...) <...>)


### PR DESCRIPTION
This solves one of the annoying `#<procedure #f ...>` cases that I had that recent commits don yet cover: `cut`-generated anonymous procedures. While source information is useful in them, knowing that they were `cut`-generated is even more useful, as simple source `grep` can easily find all occurrences of `cut` in the code, which is simple and actionable.

Thus this change: generating `%cut%` as the name of all `cut`-generated procedures for instant recognizability. 

One downside is that they might look too similar now, and that
``` scheme
(let ((name (cut display <>))) 
  name)
;; #<procedure %cut% 1>
```
which is somewhat of a rare case, as `let`-binding effectively defeats the purpose of `cut`, right?

Aside: Is there some better way to type `cut`-s without `let`-binding them?