### PR TITLE
Include the non-matching data in the "no matching pattern" error

### DIFF
--- a/lib/chibi/match/match.scm
+++ b/lib/chibi/match/match.scm
@@ -333,7 +333,7 @@
   (syntax-rules (=>)
     ;; no more clauses, the match failed
     ((match-next v g+s)
-     (error 'match "no matching pattern"))
+     (error 'match "no matching pattern" v))
     ;; named failure continuation
     ((match-next v g+s (pat (=> failure) . body) . rest)
      (let ((failure (lambda () (match-next v g+s . rest))))


### PR DESCRIPTION
The “no matching pattern” error not mentioning the mismatched data brings a lot of pain to me, due to using `match` a lot on diverse inputs. I have to insert extra error clauses just to avoid this error.

``` scheme
[something-else
 (error "No match: " something else)]
```

Listing the offending data in “no matching pattern” clause seems relatively intuitive, thus the patch.

Am I missing something? Why wasn’t it present before?