### PR TITLE
Fix test running on Guile, Mosh and Racket

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1752,8 +1752,8 @@
              `(gosh -A ,install-dir ,file)))
         ((guile)
          (if lib-path
-             `(guile -L ,install-dir -L ,lib-path ,file)
-             `(guile -L ,install-dir ,file)))
+             `(guile --r7rs -L ,install-dir -L ,lib-path ,file)
+             `(guile --r7rs -L ,install-dir ,file)))
         ((kawa)
          (let ((install-dir (path-resolve install-dir (current-directory))))
            (if lib-path
@@ -1780,8 +1780,9 @@
                `(mit-scheme --batch-mode --load ,file --eval "(exit 0)"))))
         ((mosh)
          (if lib-path
-             `(mosh ,(string-append "--loadpath=" install-dir) --loadpath= ,lib-path ,file)
-             `(mosh ,(string-append "--loadpath=" install-dir) ,file)))
+           `(mosh ,(string-append "--loadpath=" install-dir)
+                  ,(string-append "--loadpath=" lib-path) ,file)
+           `(mosh ,(string-append "--loadpath=" install-dir) ,file)))
         ((larceny)
          (if lib-path
              `(larceny -r7rs -path ,(string-append install-dir ":" lib-path)
@@ -2409,8 +2410,6 @@
            (cons binld-file installed-files))
           (else installed-files))))
 
-;; Racket can only load files with .rkt suffix. So for each library we create
-;; a file that sets language to r7rs and includes the .sld file
 (define (racket-installer impl cfg library dir)
   (let* ((source-rkt-file
            (make-path dir
@@ -2420,17 +2419,7 @@
          (dest-rkt-file
            (make-path install-dir
                       (string-append (library->path cfg library) ".rkt")))
-         (path (make-path install-dir dest-rkt-file))
-         (include-filename (string-append
-                             (path-strip-directory (path-strip-extension path))
-                             ".sld"))
          (installed-files (default-installer impl cfg library dir)))
-    (with-output-to-file
-      source-rkt-file
-      (lambda ()
-        (map display
-             (list "#lang r7rs" #\newline
-                   "(include \"" include-filename "\")" #\newline))))
     (install-file cfg source-rkt-file dest-rkt-file)
     (cons dest-rkt-file installed-files)))
 
@@ -2711,6 +2700,30 @@
                          " - install anyway?"))
          library)))
 
+;; Racket can only load files with .rkt suffix. So for each library we create
+;; a file that sets language to r7rs and includes the .sld file
+(define (racket-builder impl cfg library dir)
+  (let* ((source-rkt-file
+           (make-path
+             dir
+             (string-append (path-strip-extension (get-library-file cfg library))
+                            ".rkt")))
+         (install-dir (get-install-source-dir impl cfg))
+         (dest-rkt-file
+           (make-path install-dir
+                      (string-append (library->path cfg library) ".rkt")))
+         (path (make-path install-dir dest-rkt-file))
+         (include-filename (string-append
+                             (path-strip-directory (path-strip-extension path))
+                             ".sld")))
+    (with-output-to-file
+      source-rkt-file
+      (lambda ()
+        (map display
+             (list "#lang r7rs" #\newline
+                   "(include \"" include-filename "\")" #\newline))))
+    library))
+
 (define (lookup-builder builder)
   (case builder
     ((chibi) chibi-builder)
@@ -2720,11 +2733,12 @@
     ((guile) guile-builder)
     ((kawa) kawa-builder)
     ((mit-scheme) mit-scheme-builder)
+    ((racket) racket-builder)
     (else default-builder)))
 
 (define (builder-for-implementation impl cfg)
   (case impl
-    ((chibi chicken cyclone gambit guile kawa mit-scheme) impl)
+    ((chibi chicken cyclone gambit guile kawa mit-scheme racket) impl)
     (else 'default)))
 
 (define (build-library impl cfg library dir)


### PR DESCRIPTION
After these fixes all implementations except mit-scheme run tests on (retropikzel hello). Meaning that the test program starts and displays hello. So the test running itself works.