### PR TITLE
Add test-package command to snow-chibi

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -653,6 +653,19 @@
       (write-bytevector tarball out)
       (close-output-port out))))
 
+(define (command/test-package cfg spec pkg-file)
+  (call-with-temp-dir
+    "pkg-test"
+    (lambda (dir preserve)
+      (let* ((pkg (package-file-meta pkg-file))
+             (snowball (maybe-gunzip (file->bytevector pkg-file)))
+             (test-cfg
+               (conf-extend cfg
+                            (list '(command (test-package (show-tests? . #t)))))))
+        (tar-extract snowball (lambda (f) (make-path dir (path-strip-top f))))
+        (test-package 'chibi test-cfg pkg dir)))))
+
+
 (define (command/install-dependencies cfg spec scm-file)
   (let ((dependencies (extract-program-dependencies scm-file)))
     (cond ((null? dependencies)
@@ -1892,11 +1905,12 @@
                (display error)
                #f)
               (else
-               (info "All tests passed.")
                (cond ((or (conf-get cfg '(command install show-tests?))
-                          (conf-get cfg '(command upgrade show-tests?)))
+                          (conf-get cfg '(command upgrade show-tests?))
+                          (conf-get cfg '(command test-package show-tests?)))
                       (display output)
                       (display error)))
+               (info "All tests passed.")
                #t)))
             (other
              (warn "Test error: " other)

--- a/lib/chibi/snow/commands.sld
+++ b/lib/chibi/snow/commands.sld
@@ -1,6 +1,7 @@
 
 (define-library (chibi snow commands)
   (export command/package
+          command/test-package
           command/gen-key
           command/reg-key
           command/sign

--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -156,8 +156,10 @@
     (test-library sexp)
     (sig-file existing-filename)
     (output filename)
-    (output-dir dirname)
-    ))
+    (output-dir dirname)))
+(define test-package-spec
+  '((show-tests? boolean ("show-tests") "show test output even on success")
+    (pkg-file filename)))
 (define upload-spec
   `((uri string)
     ,@package-spec))
@@ -189,6 +191,9 @@
      (install-dependencies
       "install program dependencies"
       (@ ,@install-dependencies-spec) (,command/install-dependencies files ...))
+     (test-package
+      "test packaged library"
+      (@ ,@test-package-spec) (,command/test-package pkg-file ...))
      (upgrade
       "upgrade installed packages"
       (@ ,@upgrade-spec) (,command/upgrade names ...))


### PR DESCRIPTION
- Add test-package command
   - --show-tests? is always on when using this command
- Move the "All tests passed." to be outputted after test output


Edit:
This should be okayish workaround for **https://github.com/ashinn/chibi-scheme/issues/1148**

Edit 2:
To test quickly:
```
cd /tmp
wget https://snow-fort.org/s/iki.fi/retropikzel/retropikzel/hello/1.2.3/retropikzel-hello-1.2.3.tgz
snow-chibi test-package retropikzel-hello-1.2.3.tgz
```