### PR TITLE
Fix test-package command to work on all implementations

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -654,16 +654,20 @@
       (close-output-port out))))
 
 (define (command/test-package cfg spec pkg-file)
-  (call-with-temp-dir
-    "pkg-test"
-    (lambda (dir preserve)
-      (let* ((pkg (package-file-meta pkg-file))
-             (snowball (maybe-gunzip (file->bytevector pkg-file)))
-             (test-cfg
-               (conf-extend cfg
-                            (list '(command (test-package (show-tests? . #t)))))))
-        (tar-extract snowball (lambda (f) (make-path dir (path-strip-top f))))
-        (test-package 'chibi test-cfg pkg dir)))))
+  (let ((impls (conf-get cfg 'implementations 'chibi)))
+    (for-each
+      (lambda (impl)
+        (call-with-temp-dir
+          "pkg-test"
+          (lambda (dir preserve)
+            (let* ((pkg (package-file-meta pkg-file))
+                   (snowball (maybe-gunzip (file->bytevector pkg-file)))
+                   (test-cfg
+                     (conf-extend cfg
+                                  (list '(command (test-package (show-tests? . #t)))))))
+              (tar-extract snowball (lambda (f) (make-path dir (path-strip-top f))))
+              (test-package impl test-cfg pkg dir)))))
+      (if (list? impls) impls (list impls)))))
 
 
 (define (command/install-dependencies cfg spec scm-file)
@@ -1856,6 +1860,7 @@
                           (else #f)))
          (command (scheme-program-command impl cfg test-file dir)))
     (when (conf-get cfg 'verbose?)
+      (info "Implementation: " impl)
       (info "Testing: " (package-name pkg))
       (info "With command: " (string-join (map x->string command) " ")))
     (cond

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -664,7 +664,8 @@
                    (snowball (maybe-gunzip (file->bytevector pkg-file)))
                    (test-cfg
                      (conf-extend cfg
-                                  (list '(command (test-package (show-tests? . #t)))))))
+                                  (list '(command (test-package (show-tests? . #t)))
+                                        '(always-yes? . #t)))))
               (tar-extract snowball (lambda (f) (make-path dir (path-strip-top f))))
               (test-package impl test-cfg pkg dir)))))
       (if (list? impls) impls (list impls)))))

--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -654,21 +654,20 @@
       (close-output-port out))))
 
 (define (command/test-package cfg spec pkg-file)
-  (let ((impls (conf-get cfg 'implementations 'chibi)))
-    (for-each
-      (lambda (impl)
-        (call-with-temp-dir
-          "pkg-test"
-          (lambda (dir preserve)
-            (let* ((pkg (package-file-meta pkg-file))
-                   (snowball (maybe-gunzip (file->bytevector pkg-file)))
-                   (test-cfg
-                     (conf-extend cfg
-                                  (list '(command (test-package (show-tests? . #t)))
-                                        '(always-yes? . #t)))))
-              (tar-extract snowball (lambda (f) (make-path dir (path-strip-top f))))
-              (test-package impl test-cfg pkg dir)))))
-      (if (list? impls) impls (list impls)))))
+  (for-each
+    (lambda (impl)
+      (call-with-temp-dir
+        "pkg-test"
+        (lambda (dir preserve)
+          (let* ((pkg (package-file-meta pkg-file))
+                 (snowball (maybe-gunzip (file->bytevector pkg-file)))
+                 (test-cfg
+                   (conf-extend cfg
+                                (list '(command (test-package (show-tests? . #t)))
+                                      '(always-yes? . #t)))))
+            (tar-extract snowball (lambda (f) (make-path dir (path-strip-top f))))
+            (test-package impl test-cfg pkg dir)))))
+    (conf-get-list cfg 'implementations '(chibi))))
 
 
 (define (command/install-dependencies cfg spec scm-file)


### PR DESCRIPTION
I forgot my test value into the previous code, so any test run was run with Chibi. 

- Fixes that
- Allows to use the multiple --impls=chibi,chicken,gauche form
- verbose?  output has implementation too
- Add always-yes? true when running tests, otherwise if the tests fail snow-chibi will ask do you want to continue


Quick way to test:
```
cd /tmp
wget https://snow-fort.org/s/iki.fi/retropikzel/srfi/64/0.2.1/srfi-64-0.2.1.tgz
snow-chibi test-package --impls=chibi --verbose?=1 srfi-64-0.2.1.tgz
snow-chibi test-package --impls=cyclone --verbose?=1 srfi-64-0.2.1.tgz
```

The tests will fail on Cyclone, which is expected.