### PR TITLE
Add -h and --help

### DIFF
--- a/tools/snow-chibi.scm
+++ b/tools/snow-chibi.scm
@@ -238,12 +238,15 @@
       (@ ,@implementations-spec) (,command/implementations))
      (help
       "print help"
-      (,app-help-command args ...))
-     )))
+      (,app-help-command args ...)))))
 
 (run-application
   app-spec
-  (command-line)
+  (if (and (> (length (command-line)) 1)
+           (or (string=? "-h" (list-ref (command-line) 1))
+               (string=? "--help" (list-ref (command-line) 1))))
+    '("snow-chibi" "help")
+    (command-line))
   (let ((conf-file (conf-default-path "snow")))
     (cond ((file-exists? conf-file)
            (conf-load conf-file))


### PR DESCRIPTION
This is small improvement for when completely new user tries to run `snow-chibi --help` or `snow-chibi -h`. Instead of error with this it makes it as same as `snow-chibi help`. If there is a better way to do this I'm all ears. :)