### PR TITLE
Memoize native-srfi-support

### DIFF
--- a/lib/chibi/snow/commands.scm
+++ b/lib/chibi/snow/commands.scm
@@ -1967,7 +1967,7 @@
 
 ;; chibi is not included because chibi is already installed with full
 ;; package information for each builtin library
-(define (native-srfi-support impl cfg)
+(define-memoized (native-srfi-support impl cfg)
   (letrec*
     ((max-srfis 500)
      (srfi-conds '())

--- a/lib/chibi/snow/commands.sld
+++ b/lib/chibi/snow/commands.sld
@@ -47,6 +47,7 @@
           (chibi filesystem)
           (chibi io)
           (chibi match)
+          (chibi memoize)
           (chibi modules)
           (chibi net http)
           (chibi process)


### PR DESCRIPTION
native-srfi-support is quite heavy for chibi and it executes quite heavy code on the target implementation too so memoizationising (what a word :smile: ) it makes things much faster.