### PR TITLE
Fix SRFI 231 array-decurry and array-block applying source getters more than once

### DIFF
--- a/lib/srfi/231/test.sld
+++ b/lib/srfi/231/test.sld
@@ -3359,6 +3359,70 @@
               (make-array (make-interval '#(0)) list))))
         )
 
+      ;; https://github.com/ashinn/chibi-scheme/issues/1105
+      ;; SRFI 231 requires a source array's getter be applied at most once
+      ;; per multi-index (matters for one-shot getters such as reading the
+      ;; elements of an image sequentially from a file).  array-decurry and
+      ;; array-block used to read the corner element more than once.  This
+      ;; mirrors the tracker test from the reporter, @gambiteer (Bradley
+      ;; Lucier, the SRFI 231 author): wrap a source array so a second read
+      ;; of any multi-index trips a flag, then assert the flag stays clear.
+      (test-group "getter applied at most once (issue #1105)"
+        (let ()
+          ;; Wrap arr over the same domain; set (vector-ref flag 0) to #t
+          ;; if any multi-index is read more than once.
+          (define (track arr flag)
+            (let* ((domain (array-domain arr))
+                   (seen (make-specialized-array domain u1-storage-class 0))
+                   (seen_ (array-getter seen))
+                   (seen! (array-setter seen))
+                   (get (array-getter arr)))
+              (make-array
+               domain
+               (lambda multi-index
+                 (if (not (eqv? (apply seen_ multi-index) 0))
+                     (vector-set! flag 0 #t))
+                 (apply seen! 1 multi-index)
+                 (apply get multi-index)))))
+          ;; array-assign! and array-append already satisfy the requirement.
+          (test-assert "array-assign! reads each source element at most once"
+            (let* ((flag (vector #f))
+                   (dest (array-copy (make-array (make-interval '#(2 2)) list)
+                                     generic-storage-class #t))
+                   (src (track (make-array (make-interval '#(2 2)) list) flag)))
+              (array-assign! dest src)
+              (not (vector-ref flag 0))))
+          (test-assert "array-append reads each source element at most once"
+            (let* ((flag (vector #f))
+                   (a (track (make-array (make-interval '#(2 2)) list) flag))
+                   (b (track (make-array (make-interval '#(2 2)) list) flag)))
+              (array-append 0 (list a b))
+              (not (vector-ref flag 0))))
+          ;; Regression cases: these used to read the corner element twice.
+          (test-assert "array-decurry reads each source element at most once"
+            (let* ((flag (vector #f))
+                   (a (make-array (make-interval '#(2 2)) list))
+                   (b (make-array (make-interval '#(2 2)) list))
+                   (outer (track (make-array (make-interval '#(2))
+                                             (lambda (i) (list-ref (list a b) i)))
+                                 flag)))
+              (array-decurry outer)
+              (not (vector-ref flag 0))))
+          (test-assert "array-block reads each source element at most once"
+            (let* ((flag (vector #f))
+                   (a (make-array (make-interval '#(2 2)) list))
+                   (b (make-array (make-interval '#(2 2)) list))
+                   (b* (make-array (make-interval '#(2 2)) list))
+                   (outer (track (make-array (make-interval '#(2 2))
+                                             (lambda (i j)
+                                               (list-ref (list-ref (list (list a b)
+                                                                         (list a b*))
+                                                                   i)
+                                                         j)))
+                                 flag)))
+              (array-block outer)
+              (not (vector-ref flag 0))))))
+
       (test-group "assign/product"
         (do ((i 0 (fx+ i 1)))
             ((fx=? i tests))

--- a/lib/srfi/231/transforms.scm
+++ b/lib/srfi/231/transforms.scm
@@ -792,7 +792,12 @@
                    (car (cddr o))
                    (specialized-array-default-safe?))))
     (assert (and (array? a) (not (interval-empty? (array-domain a)))))
-    (let* ((a-domain (array-domain a))
+    ;; Materialize a once so each source getter is applied at most once
+    ;; per multi-index, as SRFI 231 requires (matters for one-shot
+    ;; getters such as sequential file reads).  Every later read below
+    ;; hits the copy.  a holds tile references, so the copy is cheap.
+    (let* ((a (array-copy a generic-storage-class))
+           (a-domain (array-domain a))
            (get (array-getter a))
            (index0 (interval-lower-bounds->list a-domain)))
       (assert (array? (apply get index0)))
@@ -851,6 +856,12 @@
          (safe? (if (and (pair? o) (pair? (cdr o)) (pair? (cddr o)))
                     (car (cddr o))
                     (specialized-array-default-safe?)))
+         ;; Materialize a once so each source getter is applied at most
+         ;; once per multi-index, as SRFI 231 requires (matters for
+         ;; one-shot getters such as sequential file reads).  Reading elt0
+         ;; and the array-assign! loop below both hit the copy.  a holds
+         ;; sub-array references, so the copy is cheap.
+         (a (array-copy a generic-storage-class))
          (a-domain (array-domain a))
          (elt0 (apply array-ref a (interval-lower-bounds->list a-domain)))
          (elt-domain (array-domain elt0))


### PR DESCRIPTION
Fixes #1105.

## Problem
SRFI 231 requires that a source array's getter be applied **at most once** per multi-index -- this matters for one-shot getters, e.g. an array whose elements are read sequentially from an image file, where a second read runs past the end of the file.

`array-decurry` and `array-block` violate this:

- `array-decurry` reads the corner element once via `(apply array-ref a ...)` to determine the element domain, then reads *every* element again in `(array-for-each array-assign! curried-res a)` -- the corner is read twice.
- `array-block` reads the corner element in the initial `(assert (array? (apply get index0)))`, again in the tile-offsets loop when `i` is the lower bound, and again in the main `interval-for-each`.

Reporter @gambiteer (Bradley Lucier, the SRFI 231 author) demonstrated this with a tracker that errors "getter applied more than once"; `array-assign!` and `array-append` already pass, `array-decurry` and `array-block` fail.

## Fix
Materialize the source array once at entry with `(array-copy a generic-storage-class)`, so the original getter fires exactly once (array-copy reads each source element exactly once via `array-assign!`) and every subsequent read hits the materialized copy. The outer array holds only sub-array/tile references, so the copy is cheap, and both transforms already return eager specialized arrays so there is no change to laziness.

A more surgical single-getter variant (threading the already-read corner element through, instead of copying) is possible if you'd prefer it -- happy to switch. The materialize-once approach is the minimal, clearly-correct fix.

## Testing
Added a tracker-based regression test to `lib/srfi/231/test.sld` mirroring the reporter's approach (wrap a source array so a second read of any multi-index trips a flag), covering `array-assign!` and `array-append` as passing controls plus `array-decurry` and `array-block` as the regressions.

- Before the fix: the two new cases FAIL (getter applied more than once).
- After the fix: all pass. Full SRFI 231 suite: 579/579 tests pass, no regression.

Credit to @gambiteer for the report and the tracker test.

---
This change was prepared with AI assistance and reviewed by me before submission.