### PR TITLE
fix reading of \x80; in string

### DIFF
--- a/sexp.c
+++ b/sexp.c
@@ -2633,7 +2633,7 @@ sexp sexp_read_string (sexp ctx, sexp in, int sentinel) {
           }
           c = sexp_unbox_fixnum(res);
 #if SEXP_USE_UTF8_STRINGS
-          if ((unsigned)c > 0x80) {
+          if ((unsigned)c >= 0x80) {
             len = sexp_utf8_char_byte_count(c);
             sexp_utf8_encode_char((unsigned char*)buf + i, len, c);
             i += len;


### PR DESCRIPTION
Writing "\x80;" left one with a corrupted string because it wasn't decoded properly. This caused strange issues like `(string-length "\x80;") => 1` and `(string->list "\x80;") => 0`.