### PR TITLE
Another attempt to generate smarter arity-inspectable case-lambdas

### DIFF
--- a/lib/srfi/16.sld
+++ b/lib/srfi/16.sld
@@ -26,6 +26,8 @@
          (%case-lambda (shortest ... (arg ...)) (args ...) clauses ...))
         ;; When ran out, generate a lambda with shortest args followed
         ;; by rest arg
+        ;; This (arg . _) is here because we need to “flatten” the
+        ;; nested list
         ((%case-lambda ((arg . _) ...) non-parsed-args clauses ...)
          (lambda (arg ... . rest)
            (let ((len (length `((unquote arg) ... . (unquote rest)))))

--- a/lib/srfi/16.sld
+++ b/lib/srfi/16.sld
@@ -3,21 +3,41 @@
   (export case-lambda)
   (import (chibi))
   (begin
-   (define-syntax %case
-     (syntax-rules ()
-       ((%case args len n p ((params ...) . body) . rest)
-        (if (= len (length '(params ...)))
-            (apply (lambda (params ...) . body) args)
-            (%case args len 0 () . rest)))
-       ((%case args len n (p ...) ((x . y) . body) . rest)
-        (%case args len (+ n 1) (p ... x) (y . body) . rest))
-       ((%case args len n (p ...) (y . body) . rest)
-        (if (>= len n)
-            (apply (lambda (p ... . y) . body) args)
-            (%case args len 0 () . rest)))
-       ((%case args len n p)
-        (error "case-lambda: no cases matched"))))
-   (define-syntax case-lambda
-     (syntax-rules ()
-       ((case-lambda . clauses)
-        (lambda args (let ((len (length* args))) (%case args len 0 () . clauses))))))))
+    ;; Macro generating the actual arity-checking cases
+    (define-syntax %case
+      (syntax-rules ()
+        ((%case (args ...) len n p ((params ...) . body) . rest)
+         (if (= len (length '(params ...)))
+             (apply (lambda (params ...) . body) args ...)
+             (%case (args ...) len 0 () . rest)))
+        ((%case (args ...) len n (p ...) ((x . y) . body) . rest)
+         (%case (args ...) len (+ n 1) (p ... x) (y . body) . rest))
+        ((%case (args ...) len n (p ...) (y . body) . rest)
+         (if (>= len n)
+             (apply (lambda (p ... . y) . body) args ...)
+             (%case (args ...) len 0 () . rest)))
+        ((%case args len n p)
+         (error "case-lambda: no cases matched"))))
+    ;; Helper for the case-lambda with inspectable minimal arity
+    (define-syntax %case-lambda
+      (syntax-rules ()
+        ;; Walk args until common ones run out
+        ((%case-lambda (shortest ...) ((arg . args) ...) clauses ...)
+         (%case-lambda (shortest ... (arg ...)) (args ...) clauses ...))
+        ;; When ran out, generate a lambda with shortest args followed
+        ;; by rest arg
+        ((%case-lambda ((arg . _) ...) non-parsed-args clauses ...)
+         (lambda (arg ... . rest)
+           (let ((len (length `((unquote arg) ... . (unquote rest)))))
+             (%case (arg ... rest) len 0 () clauses ...))))))
+    (define-syntax case-lambda
+      (syntax-rules ()
+        ;; Recursive case, walking required args
+        ((case-lambda ((args ... . rest) body ...) ...)
+         (%case-lambda () ((args ...) ...) ((args ... . rest) body ...) ...))
+        ;; Terminal case for case-lambda with atypical arglists, like
+        ;; rest-symbol-only arglists.
+        ((case-lambda (args body ...) ...)
+         (lambda rest-arg
+           (let ((len (length rest-arg)))
+             (%case (rest-arg) len 0 () (args body ...) ...))))))))

--- a/lib/srfi/16.sld
+++ b/lib/srfi/16.sld
@@ -30,7 +30,8 @@
         ;; nested list
         ((%case-lambda ((arg . _) ...) non-parsed-args clauses ...)
          (lambda (arg ... . rest)
-           (let ((len (length `((unquote arg) ... . (unquote rest)))))
+           (let ((len (+ (length '(arg ...))
+                         (length rest))))
              (%case (arg ... rest) len 0 () clauses ...))))))
     (define-syntax case-lambda
       (syntax-rules ()

--- a/lib/srfi/16/test.sld
+++ b/lib/srfi/16/test.sld
@@ -1,6 +1,6 @@
 (define-library (srfi 16 test)
   (export run-tests)
-  (import (chibi) (chibi test) (srfi 16))
+  (import (chibi) (chibi test) (chibi ast) (srfi 16))
   (begin
     (define (run-tests)
       (define plus
@@ -39,5 +39,18 @@
       (test "" (print-to-string))
       (test "hi" (print-to-string 'hi))
       (test "hi there world" (print-to-string 'hi 'there 'world))
+
+      ;; Testing smart inspectable minimal arity
+
+      ;; Test rest arg presence resulting in fully variadic lambda
+      (test 0 (procedure-arity (case-lambda (a 1))))
+      (test 0 (procedure-arity (case-lambda ((a b c) 1) (a 1))))
+      (test 0 (procedure-arity (case-lambda (a 1) ((a b c) 1))))
+
+      ;; Test shortest arglist of 1 and 2
+      (test 1 (procedure-arity (case-lambda ((a) 1) ((a b) 1) ((a b c) 1))))
+      (test 1 (procedure-arity (case-lambda ((a) 1) ((a b c) 1) ((a b) 1))))
+      (test 2 (procedure-arity (case-lambda ((a b) 1) ((a b c) 1))))
+      (test 2 (procedure-arity (case-lambda ((a b c) 1) ((a b) 1))))
 
       (test-end))))

--- a/lib/srfi/16/test.sld
+++ b/lib/srfi/16/test.sld
@@ -47,7 +47,9 @@
       (test 0 (procedure-arity (case-lambda ((a b c) 1) (a 1))))
       (test 0 (procedure-arity (case-lambda (a 1) ((a b c) 1))))
 
-      ;; Test shortest arglist of 1 and 2
+      ;; Test shortest arglist of 0, 1, and 2
+      (test 0 (procedure-arity (case-lambda (() 1) ((a b) 1) ((a b c) 1))))
+      (test 0 (procedure-arity (case-lambda ((a b c) 1) (() 1) ((a b) 1))))
       (test 1 (procedure-arity (case-lambda ((a) 1) ((a b) 1) ((a b c) 1))))
       (test 1 (procedure-arity (case-lambda ((a) 1) ((a b c) 1) ((a b) 1))))
       (test 2 (procedure-arity (case-lambda ((a b) 1) ((a b c) 1))))

--- a/lib/srfi/16/test.sld
+++ b/lib/srfi/16/test.sld
@@ -55,4 +55,9 @@
       (test 2 (procedure-arity (case-lambda ((a b) 1) ((a b c) 1))))
       (test 2 (procedure-arity (case-lambda ((a b c) 1) ((a b) 1))))
 
+      ;; Minimal arity + rest
+      (test 2 (procedure-arity (case-lambda ((a b) 1) ((a b . c) 1))))
+      (test 2 (procedure-arity (case-lambda ((a b . c) 1) ((a b) 1))))
+      (test 0 (procedure-arity (case-lambda ((a b . c) 1) ((a b) 1) (x 1))))
+
       (test-end))))

--- a/lib/srfi/16/test.sld
+++ b/lib/srfi/16/test.sld
@@ -56,6 +56,7 @@
       (test 2 (procedure-arity (case-lambda ((a b c) 1) ((a b) 1))))
 
       ;; Minimal arity + rest
+      (test 1 (procedure-arity (case-lambda ((a . c) 1) ((a b) 1))))
       (test 2 (procedure-arity (case-lambda ((a b) 1) ((a b . c) 1))))
       (test 2 (procedure-arity (case-lambda ((a b . c) 1) ((a b) 1))))
       (test 0 (procedure-arity (case-lambda ((a b . c) 1) ((a b) 1) (x 1))))


### PR DESCRIPTION
Yes, I’m at it again—trying to make `case-lambda`-generated lambdas to have more inspectable and truthful arities. This time, the implementation is short (17 lines -> 30 lines,) tested, documented, and more straightforward in general. Expansion time shouln’t be too long either, especially compared to the previous attempt (#1167), where a whole set of recursive macros handling arglists was used.

@ashinn how does that look?