### PR TITLE
Use SRFI-145 assume in SRFI-253 code

### DIFF
--- a/lib/srfi/253.sld
+++ b/lib/srfi/253.sld
@@ -2,9 +2,9 @@
   (import (scheme base)
           (scheme case-lambda)
           (scheme list)
-          (chibi assert)
           (chibi ast)
           (chibi generic))
+  (import (srfi 145))
   (export check-impl?
           check-arg values-checked
           check-case

--- a/lib/srfi/253/impl.scm
+++ b/lib/srfi/253/impl.scm
@@ -29,7 +29,7 @@
 (define-syntax check-arg
   (syntax-rules ()
     ((_ pred val caller)
-     (assert (pred val) val caller))
+     (assume (pred val) val caller))
     ((_ pred val)
      (check-arg pred val 'check-arg))))
 
@@ -52,9 +52,9 @@
      (cond
       (clause-check clause-body ...)
       ...
-      (else (assert (or clause-check ...)
-                    "at least one branch of check-case should be true"
-                    'clause-check ...))))
+      (else (assume (or clause-check ...)
+              "at least one branch of check-case should be true"
+              'clause-check ...))))
     ((_ val (clause ...) (pred body ...) rest ...)
      (%check-case
       val


### PR DESCRIPTION
Thanks to using `assume` instead of `assert`, the checks can now be stripped off in “production” mode. Important note: tests for SRFI-253 and its dependant 273 now require a `debug` feature on, but I don’t know how to enable that for an individual test :confused: 